### PR TITLE
Create APIs for support saving all symptoms into database

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -202,8 +202,9 @@ func (s *Server) setupRouter() *gin.Engine {
 	symptomRoute := apiRoute.Group("/symptoms")
 	symptomRoute.Use(s.recognizeAccountMiddleware())
 	{
+		symptomRoute.POST("", s.createSymptom)
 		symptomRoute.GET("", s.getSymptoms)
-		symptomRoute.POST("", s.reportSymptoms)
+		symptomRoute.POST("/report", s.reportSymptoms)
 	}
 
 	behaviorRoute := apiRoute.Group("/behaviors")

--- a/api/symptom.go
+++ b/api/symptom.go
@@ -12,8 +12,34 @@ import (
 	"github.com/bitmark-inc/autonomy-api/utils"
 )
 
+func (s *Server) createSymptom(c *gin.Context) {
+	var params schema.Symptom
+
+	if err := c.BindJSON(&params); err != nil {
+		abortWithEncoding(c, http.StatusBadRequest, errorInvalidParameters, err)
+		return
+	}
+
+	id, err := s.mongoStore.CreateSymptom(params)
+	if err != nil {
+		abortWithEncoding(c, http.StatusInternalServerError, errorInternalServer, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"id": id,
+	})
+	return
+}
+
 func (s *Server) getSymptoms(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"symptoms": schema.Symptoms})
+	symptoms, err := s.mongoStore.ListSymptoms()
+	if err != nil {
+		abortWithEncoding(c, http.StatusInternalServerError, errorInternalServer, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"symptoms": symptoms})
 }
 
 func (s *Server) reportSymptoms(c *gin.Context) {

--- a/schema/symptom.go
+++ b/schema/symptom.go
@@ -18,7 +18,15 @@ var SymptomFromID = map[SymptomType]Symptom{
 	SymptomType(Face):    Symptoms[7],
 }
 
+type SymptomSource string
+
 const (
+	OfficialSymptom   SymptomSource = "official"
+	CustomizedSymptom SymptomSource = "customized"
+)
+
+const (
+	SymptomCollection       = "symptom"
 	SymptomReportCollection = "symptomReport"
 	TotalSymptomWeight      = 9
 )
@@ -35,21 +43,23 @@ const (
 )
 
 type Symptom struct {
-	ID     SymptomType `json:"id"`
-	Name   string      `json:"name"`
-	Desc   string      `json:"desc"`
-	Weight float64     `json:"-"`
+	ID     SymptomType   `json:"id" bson:"_id"`
+	Name   string        `json:"name" bson:"name"`
+	Desc   string        `json:"desc" bson:"desc"`
+	Source SymptomSource `json:"-" bson:"source"`
+	Weight float64       `json:"-" bson:"-"`
 }
 
+// The system defined symptoms. The list will be inserted into database by migration function
 var Symptoms = []Symptom{
-	{Fever, "Fever", "Body temperature above 100ºF (38ºC)", 2},
-	{Cough, "Dry cough", "Without mucous or phlegm (rattling)", 1},
-	{Fatigue, "Fatigue or tiredness", "Unusual lack of energy or feeling run down", 1},
-	{Breath, "Shortness of breath", "Constriction or difficulty inhaling fully", 1},
-	{Nasal, "Nasal congestion", "Stuffy or blocked nose", 1},
-	{Throat, "Sore throat", "Throat pain, scratchiness, or irritation", 1},
-	{Chest, "Chest pain", "Persistent pain or pressure in the chest", 1},
-	{Face, "Bluish lips or face", "Not caused by cold exposure", 1},
+	{Fever, "Fever", "Body temperature above 100ºF (38ºC)", OfficialSymptom, 2},
+	{Cough, "Dry cough", "Without mucous or phlegm (rattling)", OfficialSymptom, 1},
+	{Fatigue, "Fatigue or tiredness", "Unusual lack of energy or feeling run down", OfficialSymptom, 1},
+	{Breath, "Shortness of breath", "Constriction or difficulty inhaling fully", OfficialSymptom, 1},
+	{Nasal, "Nasal congestion", "Stuffy or blocked nose", OfficialSymptom, 1},
+	{Throat, "Sore throat", "Throat pain, scratchiness, or irritation", OfficialSymptom, 1},
+	{Chest, "Chest pain", "Persistent pain or pressure in the chest", OfficialSymptom, 1},
+	{Face, "Bluish lips or face", "Not caused by cold exposure", OfficialSymptom, 1},
 }
 
 // SymptomReportData the struct to store symptom data and score

--- a/store/mongo.go
+++ b/store/mongo.go
@@ -20,6 +20,7 @@ type MongoStore interface {
 	Group
 	Healthier
 	MongoAccount
+	SymptomList
 	SymptomReport
 	POI
 	GoodBehaviorReport


### PR DESCRIPTION
In this PR, we propose to create a new collection `symptoms` for all symptoms.

There are two new functions for MongoStore to support this change.
- CreateSymptom
- ListSymptoms

Changes to highlight:
 - There is one new API call for register a new symptoms.
 - Get symptoms api is modified accordingly to fetch data from the DB.
 - A new function added into `migrate-cli` to create index and import pre-defined symptoms.

As we discussed in Slack, I tend to change the API routing to:
```
POST /api/symptoms - Register new symptoms
GET /api/symptoms - Get all symptoms
POST /api/symptoms/report - report new symptoms
```