### PR TITLE
add metrics api

### DIFF
--- a/api/metrics.go
+++ b/api/metrics.go
@@ -30,7 +30,7 @@ func (s *Server) getMetrics(c *gin.Context) {
 		return
 	}
 
-	avgToday, avgYesterday, err := s.mongoStore.GetCommunityAvgReportCount(c.Param("reportType"), consts.CORHORT_DISTANCE_RANGE, *loc)
+	avgToday, avgYesterday, err := s.mongoStore.GetCommunityAvgReportCount(c.Param("reportType"), consts.NEARBY_DISTANCE_RANGE, *loc)
 	if err != nil {
 		abortWithEncoding(c, http.StatusInternalServerError, errorInternalServer)
 		return

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/bitmark-inc/autonomy-api/consts"
+	"github.com/bitmark-inc/autonomy-api/schema"
+)
+
+func (s *Server) getMetrics(c *gin.Context) {
+	a := c.MustGet("account")
+	account, ok := a.(*schema.Account)
+	if !ok {
+		abortWithEncoding(c, http.StatusInternalServerError, errorInternalServer)
+		return
+	}
+
+	loc := account.Profile.State.LastLocation
+	if nil == loc {
+		abortWithEncoding(c, http.StatusBadRequest, errorUnknownAccountLocation)
+		return
+	}
+
+	countToday, countYesterday, err := s.mongoStore.GetPersonalReportCount(c.Param("reportType"), account.AccountNumber)
+	if err != nil {
+		fmt.Println(err)
+		abortWithEncoding(c, http.StatusInternalServerError, errorInternalServer)
+		return
+	}
+	personalDelta := float64(1)
+	if countYesterday > 0 {
+		personalDelta = float64(countToday-countYesterday) / float64(countYesterday)
+	}
+
+	avgToday, avgYesterday, err := s.mongoStore.GetCommunityAvgReportCount(c.Param("reportType"), consts.CORHORT_DISTANCE_RANGE, *loc)
+	if err != nil {
+		abortWithEncoding(c, http.StatusInternalServerError, errorInternalServer)
+		return
+	}
+	communityDelta := float64(1)
+	if avgYesterday > 0 {
+		communityDelta = (avgToday - avgYesterday) / avgYesterday
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"me": gin.H{
+			"total_today": countToday,
+			"delta":       personalDelta,
+		},
+		"community": gin.H{
+			"avg_today": avgToday,
+			"delta":     communityDelta,
+		},
+	})
+}

--- a/api/server.go
+++ b/api/server.go
@@ -229,6 +229,12 @@ func (s *Server) setupRouter() *gin.Engine {
 		historyRoute.GET("/:reportType", s.getHistory)
 	}
 
+	metricsRoute := apiRoute.Group("/metrics")
+	metricsRoute.Use(s.recognizeAccountMiddleware())
+	{
+		metricsRoute.GET("/:reportType", s.getMetrics)
+	}
+
 	debugRoute := apiRoute.Group("/debug")
 	debugRoute.Use(s.recognizeAccountMiddleware())
 	{

--- a/score/symptom.go
+++ b/score/symptom.go
@@ -58,17 +58,17 @@ func SymptomScore(weights schema.SymptomWeights, today, yesterday schema.Nearest
 	totalWeight := totalOfficialWeight + today.CustomizedCount*1
 	score := float64(100)
 	if today.OfficialCount*maxScorePerPerson > 0 {
-		de := (today.UserCount * maxScorePerPerson) + today.CustomizedCount
-		score = 100 * (1 - (totalWeight / de))
+		de := today.UserCount*maxScorePerPerson + today.CustomizedCount
+		score = 100 * (1 - totalWeight/de)
 	} else if today.CustomizedCount > 0 {
-		score = 100 * (1 - (totalWeight / today.CustomizedCount))
+		score = 100 * (1 - totalWeight/today.CustomizedCount)
 	}
 
 	// deltaCount in percent
 	deltaInPercent := float64(100)
 
 	if countYesterday > 0 {
-		deltaInPercent = ((countToday - countYesterday) / countYesterday) / 100
+		deltaInPercent = (countToday - countYesterday) / countYesterday * 100
 	}
 	return score, totalWeight, maxScorePerPerson, deltaInPercent, today.OfficialCount, today.CustomizedCount * 1
 }

--- a/score/utils.go
+++ b/score/utils.go
@@ -1,0 +1,9 @@
+package score
+
+func ChangeRate(new, old float64) float64 {
+	rate := float64(1)
+	if old > 0 {
+		rate = (new - old) / old
+	}
+	return rate
+}

--- a/score/utils.go
+++ b/score/utils.go
@@ -1,9 +1,13 @@
 package score
 
 func ChangeRate(new, old float64) float64 {
-	rate := float64(1)
-	if old > 0 {
-		rate = (new - old) / old
+	if old == 0 {
+		if new == 0 {
+			return float64(0)
+		} else {
+			return float64(100)
+		}
 	}
-	return rate
+
+	return (new - old) / old * 100
 }

--- a/score/utils_test.go
+++ b/score/utils_test.go
@@ -1,0 +1,27 @@
+package score
+
+import (
+	"testing"
+)
+
+type changeRateTestCase struct {
+	new                float64
+	old                float64
+	expectedChangeRate float64
+}
+
+func TestChangeRate(t *testing.T) {
+	cases := []changeRateTestCase{
+		{0, 0, 0},
+		{10, 10, 0},
+		{0, 10, -100},
+		{10, 0, 100},
+		{3, 5, -40},
+		{3, 2, 50},
+	}
+	for _, c := range cases {
+		if ChangeRate(c.new, c.old) != c.expectedChangeRate {
+			t.Fatal()
+		}
+	}
+}

--- a/store/acknowledgement_metrics.go
+++ b/store/acknowledgement_metrics.go
@@ -1,0 +1,143 @@
+package store
+
+import (
+	"context"
+	"errors"
+
+	log "github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/bitmark-inc/autonomy-api/schema"
+)
+
+type groupedByUserResult struct {
+	ID    string `bson:"_id"` // '$account_number'
+	Count int64  `bson:"count"`
+}
+
+type AcknowledgementMetrics interface {
+	GetPersonalReportCount(reportType, accountNumber string) (int64, int64, error)
+	GetCommunityAvgReportCount(reportType string, meter int, loc schema.Location) (float64, float64, error)
+}
+
+func (m *mongoDB) GetPersonalReportCount(reportType, accountNumber string) (int64, int64, error) {
+	var c *mongo.Collection
+	switch reportType {
+	case "symptom":
+		c = m.client.Database(m.database).Collection(schema.SymptomReportCollection)
+	case "behavior":
+		c = m.client.Database(m.database).Collection(schema.BehaviorReportCollection)
+	default:
+		return 0, 0, errors.New("undefined report type")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	todayBeginTime := todayStartAt()
+
+	// today
+	filter := bson.M{
+		"$and": []bson.M{
+			{"account_number": accountNumber},
+			matchReportedToday(todayBeginTime),
+		},
+	}
+	countToday, err := c.CountDocuments(ctx, filter)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// yesterday
+	filter = bson.M{
+		"$and": []bson.M{
+			{"account_number": accountNumber},
+			matchReportedYesterday(todayBeginTime),
+		},
+	}
+	countYesterday, err := c.CountDocuments(ctx, filter)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return countToday, countYesterday, nil
+}
+
+func (m *mongoDB) GetCommunityAvgReportCount(reportType string, meter int, loc schema.Location) (float64, float64, error) {
+	var c *mongo.Collection
+	switch reportType {
+	case "symptom":
+		c = m.client.Database(m.database).Collection(schema.SymptomReportCollection)
+	case "behavior":
+		c = m.client.Database(m.database).Collection(schema.BehaviorReportCollection)
+	default:
+		return 0, 0, errors.New("undefined report type")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	todayBeginTime := todayStartAt()
+
+	// today
+	pipeline := []bson.M{
+		aggStageGeoProximity(meter, loc),
+		aggStageReportedToday(todayBeginTime),
+		aggStageUserReportCount(),
+	}
+	cur, err := c.Aggregate(ctx, pipeline)
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{"prefix": mongoLogPrefix}).Error("failed to count user report")
+		return 0, 0, err
+	}
+	result := make([]groupedByUserResult, 0)
+	for cur.Next(ctx) {
+		var item groupedByUserResult
+		if err = cur.Decode(&item); err != nil {
+			log.WithError(err).WithFields(log.Fields{"prefix": mongoLogPrefix}).Error("failed to decode aggreaged result")
+			return 0, 0, err
+		}
+		result = append(result, item)
+	}
+	avgToday := calculateAvgCount(result)
+
+	// yesterday
+	pipeline = []bson.M{
+		aggStageGeoProximity(meter, loc),
+		aggStageReportedYesterday(todayBeginTime),
+		aggStageUserReportCount(),
+	}
+
+	cur, err = c.Aggregate(ctx, pipeline)
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{"prefix": mongoLogPrefix}).Error("failed to count user report")
+		return 0, 0, err
+	}
+	result = make([]groupedByUserResult, 0)
+	for cur.Next(ctx) {
+		var item groupedByUserResult
+		if err = cur.Decode(&item); err != nil {
+			log.WithError(err).WithFields(log.Fields{"prefix": mongoLogPrefix}).Error("failed to decode aggreaged result")
+			return 0, 0, err
+		}
+		result = append(result, item)
+	}
+	avgYesterday := calculateAvgCount(result)
+
+	log.WithFields(log.Fields{"prefix": mongoLogPrefix, "avg_today": avgToday, "avg_yesterday": avgYesterday}).Debug("community avg report")
+
+	return avgToday, avgYesterday, nil
+}
+
+func calculateAvgCount(result []groupedByUserResult) (avg float64) {
+	var reportCount, userCount int64
+	for _, r := range result {
+		reportCount += r.Count
+		userCount++
+	}
+	if userCount > 0 {
+		avg = float64(reportCount) / float64(userCount)
+	}
+	return
+}

--- a/store/agg.go
+++ b/store/agg.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"github.com/bitmark-inc/autonomy-api/schema"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func matchReportedToday(todayBeginTime int64) bson.M {
+	return bson.M{
+		"ts": bson.M{
+			"$gte": todayBeginTime,
+		},
+	}
+}
+
+func matchReportedYesterday(todayBeginTime int64) bson.M {
+	return bson.M{
+		"ts": bson.M{
+			"$gte": todayBeginTime - 24*60*60,
+			"$lt":  todayBeginTime,
+		},
+	}
+}
+
+func aggStageGeoProximity(maxDistance int, location schema.Location) bson.M {
+	return bson.M{
+		"$geoNear": bson.M{
+			"near": bson.M{
+				"type":        "Point",
+				"coordinates": bson.A{location.Longitude, location.Latitude},
+			},
+			"distanceField": "dist",
+			"maxDistance":   maxDistance,
+			"spherical":     true,
+			"includeLocs":   "location",
+		},
+	}
+}
+
+func aggStageReportedToday(todayBeginTime int64) bson.M {
+	return bson.M{
+		"$match": matchReportedToday(todayBeginTime),
+	}
+}
+
+func aggStageReportedYesterday(todayBeginTime int64) bson.M {
+	return bson.M{
+		"$match": matchReportedYesterday(todayBeginTime),
+	}
+}
+
+func aggStageUserReportCount() bson.M {
+	return bson.M{
+		"$group": bson.M{
+			"_id": "$account_number",
+			"count": bson.M{
+				"$sum": 1,
+			},
+		},
+	}
+}

--- a/store/mongo.go
+++ b/store/mongo.go
@@ -30,6 +30,7 @@ type MongoStore interface {
 	Geographic
 	Metric
 	ConfirmCDS
+	AcknowledgementMetrics
 }
 
 // Closer - close db connection


### PR DESCRIPTION
This PR implements APIs for metrics to be shown on the acknowledge page and also fixes a bug in delta calculation in percentage for symptom.

Some refactoring attempts in this PR:
- Add `ChangeRate` function under `score` package. 
- Add `store/agg.go` to standardize query or aggregation clauses because some of them appear several times in the repo.