### PR TITLE
data set issue does not response to API as an error

### DIFF
--- a/store/confirmCDS.go
+++ b/store/confirmCDS.go
@@ -64,7 +64,6 @@ func (m *mongoDB) CreateCDSData(result []schema.CDSData, country string) error {
 		if errs, hasErr := err.(mongo.BulkWriteException); hasErr {
 			if 1 == len(errs.WriteErrors) && DuplicateKeyCode == errs.WriteErrors[0].Code {
 				log.WithFields(log.Fields{"prefix": mongoLogPrefix, "err": errs}).Warn("createCDSData Insert data")
-				fmt.Println(err)
 				return nil
 			}
 		}
@@ -79,7 +78,7 @@ func (m mongoDB) GetCDSConfirm(loc schema.Location) (float64, float64, float64, 
 	pGeo, err := m.politicalGeoInfo(loc)
 	if err != nil {
 		log.WithFields(log.Fields{"prefix": mongoLogPrefix, "error": err}).Error(ErrPoliticalTypeGeoInfo)
-		return 0, 0, 0, err
+		return 0, 0, 0, ErrPoliticalTypeGeoInfo
 	}
 
 	log.WithFields(log.Fields{"prefix": mongoLogPrefix, "country": pGeo.Country, "lv1": pGeo.Level1, "lv2": pGeo.Level2, "lv3": pGeo.Level3}).Debug("political geo address")

--- a/store/metric.go
+++ b/store/metric.go
@@ -94,7 +94,7 @@ func (m *mongoDB) CollectRawMetrics(location schema.Location) (*schema.Metric, e
 				TotalPeople:             totalPeopleReport,
 				MaxScorePerPerson:       schema.TotalOfficialBehaviorWeight,
 				CustomizedBehaviorTotal: float64(behaviorToday.CustomizedCount),
-				Score: behaviorScore,
+				Score:                   behaviorScore,
 			},
 		},
 	}, nil
@@ -102,7 +102,14 @@ func (m *mongoDB) CollectRawMetrics(location schema.Location) (*schema.Metric, e
 
 func (m *mongoDB) SyncAccountMetrics(accountNumber string, coefficient *schema.ScoreCoefficient, location schema.Location) (*schema.Metric, error) {
 	rawMetrics, err := m.CollectRawMetrics(location)
-	if err != nil {
+	if err == ErrNoConfirmDataset || err == ErrInvalidConfirmDataset || err != ErrPoliticalTypeGeoInfo {
+		log.WithFields(log.Fields{
+			"prefix":         mongoLogPrefix,
+			"account_number": accountNumber,
+			"location":       location,
+			"err":            err,
+		}).Warn("collect confirm raw metrics")
+	} else if err != nil {
 		log.WithFields(log.Fields{
 			"prefix":         mongoLogPrefix,
 			"account_number": accountNumber,

--- a/store/metric.go
+++ b/store/metric.go
@@ -102,7 +102,7 @@ func (m *mongoDB) CollectRawMetrics(location schema.Location) (*schema.Metric, e
 
 func (m *mongoDB) SyncAccountMetrics(accountNumber string, coefficient *schema.ScoreCoefficient, location schema.Location) (*schema.Metric, error) {
 	rawMetrics, err := m.CollectRawMetrics(location)
-	if err == ErrNoConfirmDataset || err == ErrInvalidConfirmDataset || err != ErrPoliticalTypeGeoInfo {
+	if err == ErrNoConfirmDataset || err == ErrInvalidConfirmDataset || err == ErrPoliticalTypeGeoInfo {
 		log.WithFields(log.Fields{
 			"prefix":         mongoLogPrefix,
 			"account_number": accountNumber,


### PR DESCRIPTION
confirm data -set return error when data
1. Data set does not exist
2. Not Enough Data  (only 1 records/no records)
3. Can not find the political types of a geolocation
4. MongoDB operation errors

We do not return 1, 2, 3 as an error when API requests the area_profile data but record it. 
