### PR TITLE
CDS crawler use replace to be able to update for many times a day

### DIFF
--- a/crawler/crawlerCDS.go
+++ b/crawler/crawlerCDS.go
@@ -20,14 +20,14 @@ func (c cdsCrawler) Run() {
 	}
 	cdc, ok := c.countryCDC.(*cdc.CDS)
 	if ok {
-		err = c.mongoStore.CreateCDSData(cdc.Result, cdc.Country)
+		err = c.mongoStore.ReplaceCDS(cdc.Result, cdc.Country)
 		if err != nil {
 			log.WithFields(log.Fields{"prefix": logPrefix, "country": c.country, "error": err}).Error("create CDS data")
 			return
 		}
-		log.WithFields(log.Fields{"prefix": logPrefix, "country": c.country, "count": count}).Debug("data from CDS")
+		log.WithFields(log.Fields{"prefix": logPrefix, "country": c.country, "data count": count}).Debug("data from CDS")
 	} else {
-		log.WithFields(log.Fields{"prefix": logPrefix, "country": c.country, "count": count}).Error("get TW data  from CDC failed!")
+		log.WithFields(log.Fields{"prefix": logPrefix, "country": c.country}).Error("get TW data  from CDC failed!")
 	}
 }
 

--- a/crawler/main.go
+++ b/crawler/main.go
@@ -119,6 +119,7 @@ func main() {
 	if cancelInitialization != nil {
 		cancelInitialization()
 	}
+
 	crawlerUS := newCDSCrawler("United States", mStore, cdc.NewCDS("United States", "county", cdc.CDSDailyHTTP, nil, cdsURL))
 
 	crawlerUS.Run()

--- a/schema/confirmCDS.go
+++ b/schema/confirmCDS.go
@@ -11,7 +11,7 @@ type CDSData struct {
 	Deaths         float64  `json:"deaths" bson:"deaths"`
 	Recovered      float64  `json:"recovered" bson:"recovered"`
 	ReportTime     int64    `json:"report_ts" bson:"report_ts"`
-	UpdateTime     int64    `json:"update" , bson:"update"`
+	UpdateTime     int64    `json:"update_ts" bson:"update_ts"`
 	ReportTimeDate string   `json:"report_date" bson:"report_date"`
 	CountryID      string   `json:"countryId" bson:"countryId"`
 	StateID        string   `json:"stateId" bson:"stateId"`

--- a/store/confirmCDS.go
+++ b/store/confirmCDS.go
@@ -60,7 +60,6 @@ func (m *mongoDB) ReplaceCDS(result []schema.CDSData, country string) error {
 		return nil
 	}
 
-	log.WithFields(log.Fields{"prefix": mongoLogPrefix, "report_ts": result[0].ReportTime}).Debug("no record to update")
 	for _, v := range result {
 		filter := bson.M{"name": v.Name, "report_ts": v.ReportTime}
 		replacement := bson.M{

--- a/store/confirmCDS.go
+++ b/store/confirmCDS.go
@@ -60,8 +60,9 @@ func (m *mongoDB) ReplaceCDS(result []schema.CDSData, country string) error {
 		return nil
 	}
 
+	log.WithFields(log.Fields{"prefix": mongoLogPrefix, "report_ts": result[0].ReportTime}).Debug("no record to update")
 	for _, v := range result {
-		filter := bson.M{"report_ts": result[0].ReportTime}
+		filter := bson.M{"name": v.Name, "report_ts": v.ReportTime}
 		replacement := bson.M{
 			"name":        v.Name,
 			"city":        v.City,


### PR DESCRIPTION
The Daily crawler use "update" instead of the "insert" method so the crawler can be used more frequently.
The drawback is that the speed is much slower than the "insert" method but in an acceptable range.

