### PR TITLE
Exponential confirm score

### DIFF
--- a/consts/corhort.go
+++ b/consts/corhort.go
@@ -5,3 +5,5 @@ const CORHORT_DISTANCE_RANGE = 5000
 
 // hardcode: 1KM is a reasonable number for now
 const NEARBY_DISTANCE_RANGE = 1000
+
+const ConfirmScoreWindowSize = 14

--- a/external/cdc/cds.go
+++ b/external/cdc/cds.go
@@ -122,7 +122,7 @@ func (c *CDS) Run() (int, error) {
 		record.Deaths, _ = object["deaths"].(float64)
 		record.Recovered, _ = object["Recovered"].(float64)
 		year, month, day := time.Now().Date()
-		dateString := fmt.Sprintf("%s-%.2s-%.2s", year, int(month), day)
+		dateString := fmt.Sprintf("%d-%.2d-%.2d", year, int(month), day)
 
 		if len(record.Timezone) > 0 {
 			location, err := time.LoadLocation(record.Timezone[0])

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/nicksnyder/go-i18n/v2 v2.0.3
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
+	github.com/prometheus/common v0.9.1
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/sirupsen/logrus v1.5.0
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/schema/confirmCDS.go
+++ b/schema/confirmCDS.go
@@ -19,3 +19,8 @@ type CDSData struct {
 	Location       GeoJSON  `json:"location" bson:"location"`
 	Timezone       []string `json:"tz" bson:"tz"`
 }
+
+type CDSScoreDataSet struct {
+	Name  string  `json:"country" bson:"country"`
+	Cases float64 `json:"cases" bson:"cases"`
+}

--- a/schema/confirmCDS.go
+++ b/schema/confirmCDS.go
@@ -21,6 +21,7 @@ type CDSData struct {
 }
 
 type CDSScoreDataSet struct {
-	Name  string  `json:"country" bson:"country"`
-	Cases float64 `json:"cases" bson:"cases"`
+	Name           string  `json:"name" bson:"name"`
+	Cases          float64 `json:"cases" bson:"cases"`
+	ReportTimeDate string  `json:"-" bson:"report_date"`
 }

--- a/schema/confirmCDS.go
+++ b/schema/confirmCDS.go
@@ -11,7 +11,7 @@ type CDSData struct {
 	Deaths         float64  `json:"deaths" bson:"deaths"`
 	Recovered      float64  `json:"recovered" bson:"recovered"`
 	ReportTime     int64    `json:"report_ts" bson:"report_ts"`
-	UpdateTime     int64    `json:"update_ts" bson:"update_ts"`
+	UpdateTime     int64    `json:"update_ts"  bson:"update_ts"`
 	ReportTimeDate string   `json:"report_date" bson:"report_date"`
 	CountryID      string   `json:"countryId" bson:"countryId"`
 	StateID        string   `json:"stateId" bson:"stateId"`

--- a/schema/confirmCDS.go
+++ b/schema/confirmCDS.go
@@ -21,7 +21,6 @@ type CDSData struct {
 }
 
 type CDSScoreDataSet struct {
-	Name           string  `json:"name" bson:"name"`
-	Cases          float64 `json:"cases" bson:"cases"`
-	ReportTimeDate string  `json:"-" bson:"report_date"`
+	Name  string  `json:"name" bson:"name"`
+	Cases float64 `json:"cases" bson:"cases"`
 }

--- a/schema/metric.go
+++ b/schema/metric.go
@@ -1,11 +1,12 @@
 package schema
 
-import "time"
+import (
+	"time"
+)
 
 type ConfirmDetail struct {
-	Yesterday float64 `json:"yesterday" bson:"yesterday"`
-	Today     float64 `json:"today" bson:"today"`
-	Score     float64 `json:"score" bson:"score"`
+	ContinuousData []CDSScoreDataSet `json:"data" bson:"data"`
+	Score          float64           `json:"score" bson:"score"`
 }
 
 type BehaviorDetail struct {

--- a/schema/metric.go
+++ b/schema/metric.go
@@ -5,7 +5,7 @@ import (
 )
 
 type ConfirmDetail struct {
-	ContinuousData []CDSScoreDataSet `json:"data" bson:"data"`
+	ContinuousData []CDSScoreDataSet `json:"-" bson:"data"`
 	Score          float64           `json:"score" bson:"score"`
 }
 

--- a/score/confirm.go
+++ b/score/confirm.go
@@ -3,31 +3,35 @@ package score
 import (
 	"math"
 
+	"github.com/bitmark-inc/autonomy-api/consts"
 	"github.com/bitmark-inc/autonomy-api/schema"
-)
-
-const (
-	confirmDataCountThreadHold = 5
 )
 
 func CalculateConfirmScore(metric *schema.Metric) {
 	details := &metric.Details.Confirm
 	dataset := details.ContinuousData
 	score := float64(0)
-	if len(dataset) < confirmDataCountThreadHold {
-		metric.Details.Confirm.Score = score
+	sizeOfConfirmData := len(dataset)
+	if 0 == len(dataset) {
+		metric.Details.Confirm.Score = 0
 		return
+	} else if len(dataset) < consts.ConfirmScoreWindowSize {
+		zeroDay := []schema.CDSScoreDataSet{schema.CDSScoreDataSet{Name: dataset[0].Name, Cases: 0}}
+		for idx := 0; idx < consts.ConfirmScoreWindowSize-sizeOfConfirmData; idx++ {
+			dataset = append(zeroDay, dataset...)
+		}
+		details.ContinuousData = dataset
 	}
-	fraction := float64(0)
+	numerator := float64(0)
 	denominator := float64(0)
 	for idx, val := range dataset {
-		epx := (float64(idx) + 1) / 2
-		fraction = fraction + math.Exp(epx)*val.Cases
-		denominator = denominator + math.Exp(epx)*(val.Cases+1)
+		power := (float64(idx) + 1) / 2
+		numerator = numerator + math.Exp(power)*val.Cases
+		denominator = denominator + math.Exp(power)*(val.Cases+1)
 	}
 
 	if denominator > 0 {
-		score = 1 - fraction/denominator
+		score = 1 - numerator/denominator
 	}
 	metric.Details.Confirm.Score = score * 100
 }

--- a/score/confirm.go
+++ b/score/confirm.go
@@ -1,21 +1,20 @@
 package score
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/bitmark-inc/autonomy-api/schema"
 )
 
 const (
-	confirmCriteria = 10
+	confirmDataCountThreadHold = 5
 )
 
 func CalculateConfirmScore(metric *schema.Metric) {
 	details := &metric.Details.Confirm
 	dataset := details.ContinuousData
 	score := float64(0)
-	if len(dataset) < 14 {
+	if len(dataset) < confirmDataCountThreadHold {
 		metric.Details.Confirm.Score = score
 		return
 	}
@@ -31,5 +30,4 @@ func CalculateConfirmScore(metric *schema.Metric) {
 		score = 1 - fraction/denominator
 	}
 	metric.Details.Confirm.Score = score * 100
-	fmt.Println(fmt.Sprintf("score in percentage:%f     fraction:%f denominator:%f score in fraction:%f", metric.Details.Confirm.Score, fraction, denominator, score))
 }

--- a/score/confirm.go
+++ b/score/confirm.go
@@ -31,5 +31,5 @@ func CalculateConfirmScore(metric *schema.Metric) {
 		score = 1 - fraction/denominator
 	}
 	metric.Details.Confirm.Score = score * 100
-	fmt.Println(fmt.Sprintf("score:%f     fraction:%f denominator:%f score:%f", metric.Details.Confirm.Score, fraction, denominator, score))
+	fmt.Println(fmt.Sprintf("score in percentage:%f     fraction:%f denominator:%f score in fraction:%f", metric.Details.Confirm.Score, fraction, denominator, score))
 }

--- a/share/jupyter/autonomyFormula.ipynb
+++ b/share/jupyter/autonomyFormula.ipynb
@@ -1,1 +1,449 @@
-{"cells":[{"metadata":{},"cell_type":"markdown","source":"## Autonomy equations for data-set from people in MSA  \n\nThere are 3 types of data in a data-set in Autonomy. They are confirmed cases from Taiwan CDC, symptom reports, and good behavior reports from Autonomy users in a MSA area. Follows are how we calculate these indicators\n"},{"metadata":{},"cell_type":"markdown","source":"### Symptom Indicator\n+ There are two types of symptoms: **Official** & **Customized** Symptom.\n+ A user can adjust Weight for each symptom to have their score\n+ The higher number symptoms reported, the lower the score\n+ The score of symptoms is:\n\n```Score = 100 * (1 -(SumOfTotalWeight/((TotalPeople*MaxWeightPerPerson)+SumOfCustomizedWeight)))```\n\n+ Factors\n\t+ SumOfTotalWeight\n\t\t+ WeightMatrix : the weight that a user gives to each official symptom.\n\t\t```\n\t\t{\n\t\t\tFever:   3,\n\t\t\tCough:   2,\n\t\t\tFatigue: 1,\n\t\t\tBreath:  1,\n\t\t\tNasal:   1,\n\t\t\tThroat:  1,\n\t\t\tChest:   2,\n\t\t\tFace:    2,\n\t\t}\n\t\t```\n\t+ TotalPeople : total people report in the MSA at specific period (ie. today) \n\t+ MaxWeightPerPerson: the weights a person has, if the person reports all official symptoms\n\t\t+ use the WeightMatrix above, it is (3+2+1+1+1+1+2+2) = 13\n\t+ CustomizedWeight : the sum of total customized weights\n\t+ SumOfCustomizedWeight: CustomizedWeight for each symptom is 1 (so CustomizedWeight = CustomizedCount)\n\t+ Normalization: the score is 100 and the more symptoms and the lower the score\n    \n\t ```\n\t\t100 - 100*(WeightsReported/WeightWeExpectedAsA100Point)\n\t\t100*(1-(WeightsReported/WeightWeExpectedAsA100Point))\n\t\t100*(1-(SumOfTotalWeight/(((TotalPeople*MaxWeightPerPerson)+CustomizedWeight)))\n\t```"},{"metadata":{},"cell_type":"markdown","source":"#### Example data-set of symptom report\n\nIn  a MSA area there are 5 reports from A,B,C and D\n\n```\n A : Fever , customized01\n B : Fever, Dry Cought, Chest Pain\n C : Dry Cough, Fatique\n D : customized02\n```\n"},{"metadata":{},"cell_type":"markdown","source":"Data set will have below value\n+ total count of customized symptoms\n+ total people in the report\n+ total count of each official symptom in the Data-set (we call it distribution)\n+ weight metrix : user can define the weight for each official symptoms while customized weight always weight 1"},{"metadata":{"trusted":true},"cell_type":"code","source":"totalCustomizedCountSymptom = 2\ntotalPeopleSymptom = 4","execution_count":1,"outputs":[]},{"metadata":{"trusted":true},"cell_type":"code","source":"\ndistributionSymptom = {\n    'Fever':   2,\n    'Cough':   2,\n    'Fatigue': 1,\n    'Breath':  0,\n    'Nasal':   0,\n    'Throat':  0,\n    'Chest':   1,\n    'Face':    0,\n}\n","execution_count":2,"outputs":[]},{"metadata":{"trusted":true},"cell_type":"code","source":"\nweightMatrixSymptom = {\n    'Fever':   3,\n    'Cough':   2,\n    'Fatigue': 1,\n    'Breath':  1,\n    'Nasal':   1,\n    'Throat':  1,\n    'Chest':   2,\n    'Face':    2,\n}\n","execution_count":3,"outputs":[]},{"metadata":{},"cell_type":"markdown","source":"#### Equation\n+ calculate intermediate values for the final score"},{"metadata":{"trusted":true},"cell_type":"code","source":"totalWeightSymptom = 0.0\nfor key, value  in distributionSymptom.items():\n    totalWeightSymptom = totalWeightSymptom + value*weightMatrixSymptom[key]\n\nprint('totalWeightSymptom',totalWeightSymptom)\nmaxWeightPerPersonSymptom = 0.0\nfor key, value  in weightMatrixSymptom.items():\n    maxWeightPerPersonSymptom = maxWeightPerPersonSymptom + value\nprint('maxWeightPerPersonSymptom:',maxWeightPerPersonSymptom)","execution_count":4,"outputs":[{"output_type":"stream","text":"totalWeightSymptom 13.0\nmaxWeightPerPersonSymptom: 13.0\n","name":"stdout"}]},{"metadata":{},"cell_type":"markdown","source":"#### Final Score"},{"metadata":{"trusted":true},"cell_type":"code","source":"if ((totalWeightSymptom*maxWeightPerPersonSymptom)+totalCustomizedCountSymptom*1) > 0:\n    scoreSymptom = 100*(1-(totalWeightSymptom/((totalPeopleSymptom*maxWeightPerPersonSymptom)+totalCustomizedCountSymptom*1)))\nelse:\n    scoreSymptom = 100\nprint('**scoreSymptom', scoreSymptom)","execution_count":5,"outputs":[{"output_type":"stream","text":"**scoreSymptom 75.92592592592592\n","name":"stdout"}]},{"metadata":{},"cell_type":"markdown","source":"###  Behaviors Indicator\n\n+ There are two types of behaviors: **Official** & **Customized** behavior.\n+ The user can not change their **weight matrix** in Sprint3\n+ Each Official behavior weight 1 , the same as customized behavior\n+ The more good behaviors reported, the better the score\n+ The score of symptoms is:\n\n```Score = 100*(SumOfTotalWeight/((TotalPeople*MaxWeightPerPerson)+SumOfCustomizedWeight))```"},{"metadata":{},"cell_type":"markdown","source":"#### Example data-set of behavior report\n\n    ```\n     A : CleanHand , customized01\n\t B : SocialDistancing, TouchFace\n\t C : CleanHand\n\t D : customized02\n\t```\n"},{"metadata":{},"cell_type":"markdown","source":"behavior data in the autonomy data-set will have values:\n+ sum of total weights (official+customized good behaviors) \n+ total people in the report\n+ a max weight per person can have\n+ total customized weight "},{"metadata":{},"cell_type":"markdown","source":"#### Equation & final score\n"},{"metadata":{"trusted":true},"cell_type":"code","source":"# SumOfTotalWeight = 2 + 2 + 1 + 1\nSumOfTotalWeightBehavior = 6\nTotalPeopleBehavior = 4 \n# (We have 6 official behaviors)\nMaxWeightPerPersonBehavior = 6 \nSumOfCustomizedWeightBehavior = 2\nif ((TotalPeopleBehavior*MaxWeightPerPersonBehavior)+SumOfCustomizedWeightBehavior) > 0:\n    scoreBehavior = 100*(SumOfTotalWeightBehavior/((TotalPeopleBehavior*MaxWeightPerPersonBehavior)+SumOfCustomizedWeightBehavior))\nelse:\n    scoreBehavior = 0\nprint('**scoreBehavior:', scoreBehavior)","execution_count":6,"outputs":[{"output_type":"stream","text":"**scoreBehavior: 23.076923076923077\n","name":"stdout"}]},{"metadata":{},"cell_type":"markdown","source":"## Confirmed cases indicator\n+ The confirmed cases data is from [Corona Data Scraper CDS](https://coronadatascraper.com/#home) \n    + Taiwan use country level data\n    + US use county level data\n+ Score Equation　\n    + Exponential Weight Average Method\n   \n$$1 - \\dfrac{\\displaystyle\\sum_{i=1}^{14}e^{\\frac{i}{2}}d_i}{\\displaystyle\\sum_{i=1}^{14}e^{\\frac{i}{2}}(d_i+1)}$$\n"},{"metadata":{},"cell_type":"markdown","source":"### Example 1 \nIn 14 days , each day the new confirm cases is \n - day 1: 3\n - day 2: 2\n - day 3: 2\n - day 4: 1\n - day 14: 10 (last data reported)\n\n$$1 - \\dfrac{e^{0.5}*3 + e*2+ e^{1.5}*2 + e^2 * 1 + e^7*10 }{e^{0.5}*4 + e*3+ e^{1.5}*3 + e^2 * 2 + e^{2.5} +e^{3}+e^{3.5}+e^{4}+e^{4.5}+e^{5}+e^{5.5}+e^{6}+e^{6.5} + e^7*11} \\\\\n\\approx 0.20210651903685417\n$$\n\nThe score is at about 20.2 since there are much cases in the nearest day.\n\n### Example 2\nIn 14 days , each day the new confirm cases is \n - day 1: 20\n - day 2: 2\n - day 3: 2\n - day 4: 1\n - day 13: 1\n - day 14: 1 (last data reported)\n \n$$1 - \\dfrac{e^{0.5}*20 + e*2+ e^{1.5}*2 + e^2 * 1 + e^{6.5}*2+ e^7*1 }{e^{0.5}*21 + e*3+ e^{1.5}*3 + e^2 * 2 + e^{2.5} +e^{3}+e^{3.5}+e^{4}+e^{4.5}+e^{5}+e^{5.5}+e^{6}+e^{6.5}*3+ e^7*2} \\\\\n\\approx 0.5287554499517347\n$$\n\nThe score is at about 52.87 since lots of cases happended on the farthest day."},{"metadata":{},"cell_type":"markdown","source":"### A 14 days Examples"},{"metadata":{"trusted":true},"cell_type":"code","source":"confirmsCases14Days = [3, 2, 2, 1, 0, 1, 3, 4, 0, 0, 3, 3, 4, 30]","execution_count":7,"outputs":[]},{"metadata":{},"cell_type":"markdown","source":"#### Equation & final score"},{"metadata":{"trusted":true},"cell_type":"code","source":"import math\n\nfraction = 0\ndenominator = 0\nday = 1\nfor cases in  confirmsCases14Days :\n    power = day/2\n    fraction = fraction +  math.exp(power)*cases\n    denominator = denominator +  math.exp(power)*(cases+1)\n    #print(\"fraction:\",fraction, \"denominator:\",denominator, \"day:\",day)\n    day += 1\n\nscoreConfirm = 0\nif denominator > 0 :\n    scoreConfirm = 100*(1- fraction/denominator)\n\nprint('**ScoreConfirm:', scoreConfirm)","execution_count":8,"outputs":[{"output_type":"stream","text":"**ScoreConfirm: 6.849539394302084\n","name":"stdout"}]},{"metadata":{},"cell_type":"markdown","source":"##  Overall score\nAssume we can have normalized score ([0-100]) from each indicator above, we want to come up with an overall score for users as the final indicator. The most straighfoward way could be a linear combination:\n\n`final socre = c1*symptom_score + c2*behavior_score + c3*confirm_case_score`"},{"metadata":{},"cell_type":"markdown","source":"### Example\nCoefficients for each score is\n    \n    coefficient1 = 0.25 (symptom)\n    coefficient2 = 0.25 (behavior)\n    coefficient13 = 0.50 (confirmed cases)\n    \nWe use scoreSymptom , scoreBehavior and scoreConfirm from Above"},{"metadata":{"trusted":true},"cell_type":"code","source":"coefSymptom=0.25\ncoefBehavior=0.25\ncoefConfirm=0.5\nscore= coefSymptom*scoreSymptom+ coefBehavior*scoreBehavior + coefConfirm*scoreConfirm\nprint('**Autonomy Overall Score:',score)","execution_count":9,"outputs":[{"output_type":"stream","text":"**Autonomy Overall Score: 28.175481947863293\n","name":"stdout"}]}],"metadata":{"kernelspec":{"name":"python3","display_name":"Python 3","language":"python"},"language_info":{"name":"python","version":"3.7.6","mimetype":"text/x-python","codemirror_mode":{"name":"ipython","version":3},"pygments_lexer":"ipython3","nbconvert_exporter":"python","file_extension":".py"}},"nbformat":4,"nbformat_minor":4}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Autonomy equations for data-set from people in MSA  \n",
+    "\n",
+    "There are 3 types of data in a data-set in Autonomy. They are confirmed cases from Taiwan CDC, symptom reports, and good behavior reports from Autonomy users in a MSA area. Follows are how we calculate these indicators\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Symptom Indicator\n",
+    "+ There are two types of symptoms: **Official** & **Customized** Symptom.\n",
+    "+ A user can adjust Weight for each symptom to have their score\n",
+    "+ The higher number symptoms reported, the lower the score\n",
+    "+ The score of symptoms is:\n",
+    "\n",
+    "```Score = 100 * (1 -(SumOfTotalWeight/((TotalPeople*MaxWeightPerPerson)+SumOfCustomizedWeight)))```\n",
+    "\n",
+    "+ Factors\n",
+    "\t+ SumOfTotalWeight\n",
+    "\t\t+ WeightMatrix : the weight that a user gives to each official symptom.\n",
+    "\t\t```\n",
+    "\t\t{\n",
+    "\t\t\tFever:   3,\n",
+    "\t\t\tCough:   2,\n",
+    "\t\t\tFatigue: 1,\n",
+    "\t\t\tBreath:  1,\n",
+    "\t\t\tNasal:   1,\n",
+    "\t\t\tThroat:  1,\n",
+    "\t\t\tChest:   2,\n",
+    "\t\t\tFace:    2,\n",
+    "\t\t}\n",
+    "\t\t```\n",
+    "\t+ TotalPeople : total people report in the MSA at specific period (ie. today) \n",
+    "\t+ MaxWeightPerPerson: the weights a person has, if the person reports all official symptoms\n",
+    "\t\t+ use the WeightMatrix above, it is (3+2+1+1+1+1+2+2) = 13\n",
+    "\t+ CustomizedWeight : the sum of total customized weights\n",
+    "\t+ SumOfCustomizedWeight: CustomizedWeight for each symptom is 1 (so CustomizedWeight = CustomizedCount)\n",
+    "\t+ Normalization: the score is 100 and the more symptoms and the lower the score\n",
+    "    \n",
+    "\t ```\n",
+    "\t\t100 - 100*(WeightsReported/WeightWeExpectedAsA100Point)\n",
+    "\t\t100*(1-(WeightsReported/WeightWeExpectedAsA100Point))\n",
+    "\t\t100*(1-(SumOfTotalWeight/(((TotalPeople*MaxWeightPerPerson)+CustomizedWeight)))\n",
+    "\t```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example data-set of symptom report\n",
+    "\n",
+    "In  a MSA area there are 5 reports from A,B,C and D\n",
+    "\n",
+    "```\n",
+    " A : Fever , customized01\n",
+    " B : Fever, Dry Cought, Chest Pain\n",
+    " C : Dry Cough, Fatique\n",
+    " D : customized02\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Data set will have below value\n",
+    "+ total count of customized symptoms\n",
+    "+ total people in the report\n",
+    "+ total count of each official symptom in the Data-set (we call it distribution)\n",
+    "+ weight metrix : user can define the weight for each official symptoms while customized weight always weight 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "totalCustomizedCountSymptom = 2\n",
+    "totalPeopleSymptom = 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "distributionSymptom = {\n",
+    "    'Fever':   2,\n",
+    "    'Cough':   2,\n",
+    "    'Fatigue': 1,\n",
+    "    'Breath':  0,\n",
+    "    'Nasal':   0,\n",
+    "    'Throat':  0,\n",
+    "    'Chest':   1,\n",
+    "    'Face':    0,\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "weightMatrixSymptom = {\n",
+    "    'Fever':   3,\n",
+    "    'Cough':   2,\n",
+    "    'Fatigue': 1,\n",
+    "    'Breath':  1,\n",
+    "    'Nasal':   1,\n",
+    "    'Throat':  1,\n",
+    "    'Chest':   2,\n",
+    "    'Face':    2,\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Equation\n",
+    "+ calculate intermediate values for the final score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "totalWeightSymptom 13.0\n",
+      "maxWeightPerPersonSymptom: 13.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "totalWeightSymptom = 0.0\n",
+    "for key, value  in distributionSymptom.items():\n",
+    "    totalWeightSymptom = totalWeightSymptom + value*weightMatrixSymptom[key]\n",
+    "\n",
+    "print('totalWeightSymptom',totalWeightSymptom)\n",
+    "maxWeightPerPersonSymptom = 0.0\n",
+    "for key, value  in weightMatrixSymptom.items():\n",
+    "    maxWeightPerPersonSymptom = maxWeightPerPersonSymptom + value\n",
+    "print('maxWeightPerPersonSymptom:',maxWeightPerPersonSymptom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Final Score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "**scoreSymptom 75.92592592592592\n"
+     ]
+    }
+   ],
+   "source": [
+    "if ((totalWeightSymptom*maxWeightPerPersonSymptom)+totalCustomizedCountSymptom*1) > 0:\n",
+    "    scoreSymptom = 100*(1-(totalWeightSymptom/((totalPeopleSymptom*maxWeightPerPersonSymptom)+totalCustomizedCountSymptom*1)))\n",
+    "else:\n",
+    "    scoreSymptom = 100\n",
+    "print('**scoreSymptom', scoreSymptom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###  Behaviors Indicator\n",
+    "\n",
+    "+ There are two types of behaviors: **Official** & **Customized** behavior.\n",
+    "+ The user can not change their **weight matrix** in Sprint3\n",
+    "+ Each Official behavior weight 1 , the same as customized behavior\n",
+    "+ The more good behaviors reported, the better the score\n",
+    "+ The score of symptoms is:\n",
+    "\n",
+    "```Score = 100*(SumOfTotalWeight/((TotalPeople*MaxWeightPerPerson)+SumOfCustomizedWeight))```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example data-set of behavior report\n",
+    "\n",
+    "    ```\n",
+    "     A : CleanHand , customized01\n",
+    "\t B : SocialDistancing, TouchFace\n",
+    "\t C : CleanHand\n",
+    "\t D : customized02\n",
+    "\t```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "behavior data in the autonomy data-set will have values:\n",
+    "+ sum of total weights (official+customized good behaviors) \n",
+    "+ total people in the report\n",
+    "+ a max weight per person can have\n",
+    "+ total customized weight "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Equation & final score\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "**scoreBehavior: 23.076923076923077\n"
+     ]
+    }
+   ],
+   "source": [
+    "# SumOfTotalWeight = 2 + 2 + 1 + 1\n",
+    "SumOfTotalWeightBehavior = 6\n",
+    "TotalPeopleBehavior = 4 \n",
+    "# (We have 6 official behaviors)\n",
+    "MaxWeightPerPersonBehavior = 6 \n",
+    "SumOfCustomizedWeightBehavior = 2\n",
+    "if ((TotalPeopleBehavior*MaxWeightPerPersonBehavior)+SumOfCustomizedWeightBehavior) > 0:\n",
+    "    scoreBehavior = 100*(SumOfTotalWeightBehavior/((TotalPeopleBehavior*MaxWeightPerPersonBehavior)+SumOfCustomizedWeightBehavior))\n",
+    "else:\n",
+    "    scoreBehavior = 0\n",
+    "print('**scoreBehavior:', scoreBehavior)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Confirmed cases indicator\n",
+    "+ The confirmed cases data is from [Corona Data Scraper CDS](https://coronadatascraper.com/#home) \n",
+    "    + Taiwan use country level data\n",
+    "    + US use county level data\n",
+    "+ Score Equation　\n",
+    "    + Exponential Weight Average Method\n",
+    "   \n",
+    "$$1 - \\dfrac{\\displaystyle\\sum_{i=1}^{14}e^{\\frac{i}{2}}d_i}{\\displaystyle\\sum_{i=1}^{14}e^{\\frac{i}{2}}(d_i+1)}$$\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example 1 \n",
+    "In 14 days , each day the new confirm cases is \n",
+    " - day 1: 3\n",
+    " - day 2: 2\n",
+    " - day 3: 2\n",
+    " - day 4: 1\n",
+    " - day 14: 10 (last data reported)\n",
+    "\n",
+    "$$1 - \\dfrac{e^{0.5}*3 + e*2+ e^{1.5}*2 + e^2 * 1 + e^7*10 }{e^{0.5}*4 + e*3+ e^{1.5}*3 + e^2 * 2 + e^{2.5} +e^{3}+e^{3.5}+e^{4}+e^{4.5}+e^{5}+e^{5.5}+e^{6}+e^{6.5} + e^7*11} \\\\\n",
+    "\\approx 0.20210651903685417\n",
+    "$$\n",
+    "\n",
+    "The score is at about 20.2 since there are much cases in the nearest day.\n",
+    "\n",
+    "### Example 2\n",
+    "In 14 days , each day the new confirm cases is \n",
+    " - day 1: 20\n",
+    " - day 2: 2\n",
+    " - day 3: 2\n",
+    " - day 4: 1\n",
+    " - day 13: 1\n",
+    " - day 14: 1 (last data reported)\n",
+    " \n",
+    "$$1 - \\dfrac{e^{0.5}*20 + e*2+ e^{1.5}*2 + e^2 * 1 + e^{6.5}*2+ e^7*1 }{e^{0.5}*21 + e*3+ e^{1.5}*3 + e^2 * 2 + e^{2.5} +e^{3}+e^{3.5}+e^{4}+e^{4.5}+e^{5}+e^{5.5}+e^{6}+e^{6.5}*3+ e^7*2} \\\\\n",
+    "\\approx 0.5287554499517347\n",
+    "$$\n",
+    "\n",
+    "The score is at about 52.87 since lots of cases happended on the farthest day."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A 14 days Examples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "confirmsCases14Days = [3, 2, 2, 1, 0, 1, 30, 4, 0, 0, 3, 3, 4, 3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Equation & final score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "numerator: 4.946163812100385 denominator: 6.594885082800513 day: 1\n",
+      "numerator: 10.382727469018475 denominator: 14.749730568177648 day: 2\n",
+      "numerator: 19.346105609694604 denominator: 28.194797779191845 day: 3\n",
+      "numerator: 26.735161708625256 denominator: 42.97290997705315 day: 4\n",
+      "numerator: 26.735161708625256 denominator: 55.155403937756624 day: 5\n",
+      "numerator: 46.820698631812924 denominator: 95.32647778413195 day: 6\n",
+      "numerator: 1040.2842573925823 denominator: 1121.9054885035935 day: 7\n",
+      "numerator: 1258.6768575251592 denominator: 1394.8962386693147 day: 8\n",
+      "numerator: 1258.6768575251592 denominator: 1484.9133699698366 day: 9\n",
+      "numerator: 1258.6768575251592 denominator: 1633.3265290724132 day: 10\n",
+      "numerator: 1992.7526543178203 denominator: 2612.0942581292948 day: 11\n",
+      "numerator: 3203.0390347960256 denominator: 4225.809432100235 day: 12\n",
+      "numerator: 5863.605566973472 denominator: 7551.517597322045 day: 13\n",
+      "numerator: 9153.505042258848 denominator: 11938.050231035879 day: 14\n",
+      "**ScoreConfirm: 23.324957885818954\n"
+     ]
+    }
+   ],
+   "source": [
+    "import math\n",
+    "\n",
+    "numerator = 0\n",
+    "denominator = 0\n",
+    "day = 1\n",
+    "for cases in  confirmsCases14Days :\n",
+    "    power = day/2\n",
+    "    numerator = numerator +  math.exp(power)*cases\n",
+    "    denominator = denominator +  math.exp(power)*(cases+1)\n",
+    "    # print(\"numerator:\",numerator, \"denominator:\",denominator, \"day:\",day)\n",
+    "    day += 1\n",
+    "\n",
+    "scoreConfirm = 0\n",
+    "if denominator > 0 :\n",
+    "    scoreConfirm = 100*(1- numerator/denominator)\n",
+    "\n",
+    "print('**ScoreConfirm:', scoreConfirm)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##  Overall score\n",
+    "Assume we can have normalized score ([0-100]) from each indicator above, we want to come up with an overall score for users as the final indicator. The most straighfoward way could be a linear combination:\n",
+    "\n",
+    "`final socre = c1*symptom_score + c2*behavior_score + c3*confirm_case_score`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example\n",
+    "Coefficients for each score is\n",
+    "    \n",
+    "    coefficient1 = 0.25 (symptom)\n",
+    "    coefficient2 = 0.25 (behavior)\n",
+    "    coefficient13 = 0.50 (confirmed cases)\n",
+    "    \n",
+    "We use scoreSymptom , scoreBehavior and scoreConfirm from Above"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "**Autonomy Overall Score: 28.175481947863293\n"
+     ]
+    }
+   ],
+   "source": [
+    "coefSymptom=0.25\n",
+    "coefBehavior=0.25\n",
+    "coefConfirm=0.5\n",
+    "score= coefSymptom*scoreSymptom+ coefBehavior*scoreBehavior + coefConfirm*scoreConfirm\n",
+    "print('**Autonomy Overall Score:',score)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/store/confirmCDS.go
+++ b/store/confirmCDS.go
@@ -157,19 +157,26 @@ func (m mongoDB) GetCDSConfirm(loc schema.Location) (float64, float64, float64, 
 			today = results[0]
 			yesterday = results[1]
 		} else if results[0].ReportTime < results[1].ReportTime {
-			today = results[0]
-			yesterday = results[1]
+			today = results[1]
+			yesterday = results[0]
+			log.WithField("prefix", mongoLogPrefix).Errorf("cds query result error: name :%v  today:%v date:%v", results[0].Name, results[0].ReportTime, results[1].ReportTime)
 		} else {
 			return 0, 0, 0, ErrConfirmDuplicateRecord
 		}
 		delta = today.Cases - yesterday.Cases
 		if yesterday.Cases > 0 {
 			percent = 100 * delta / yesterday.Cases
-			return today.Cases, delta, percent, nil
 		} else {
 			percent = 100
 		}
+		return today.Cases, delta, percent, nil
+	} else if 1 == len(results) {
+		today = results[0]
+		delta = today.Cases
+		percent = 100
+		return today.Cases, delta, percent, nil
 	}
+
 	return 0, 0, 0, ErrInvalidConfirmDataset
 
 }

--- a/store/confirmCDS.go
+++ b/store/confirmCDS.go
@@ -112,7 +112,7 @@ func (m *mongoDB) CreateCDS(result []schema.CDSData, country string) error {
 }
 
 func (m mongoDB) GetCDSConfirm(loc schema.Location) (float64, float64, float64, error) {
-	log.WithFields(log.Fields{"prefix": mongoLogPrefix, "country": loc.Country, "lv1": loc.State, "lv2": loc.County}).Debug("GetCDSConfirm geo info")
+	log.WithFields(log.Fields{"prefix": mongoLogPrefix, "country": loc.Country, "state": loc.State, "county": loc.County}).Debug("GetCDSConfirm geo info")
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 	var results []schema.CDSData

--- a/store/confirmCDS.go
+++ b/store/confirmCDS.go
@@ -181,7 +181,6 @@ func (m mongoDB) GetCDSConfirm(loc schema.Location) (float64, float64, float64, 
 
 func (m mongoDB) ContinuousDataCDSConfirm(loc schema.Location, num int64, lessEqThan int64) ([]schema.CDSScoreDataSet, int, error) {
 	log.WithFields(log.Fields{"prefix": mongoLogPrefix, "country": loc.Country, "lv1": loc.State, "lv2": loc.County}).Debug("ContinuousDataCDSConfirm geo info")
-	lessEqThan = 1589040000
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 

--- a/store/confirmCDS.go
+++ b/store/confirmCDS.go
@@ -166,7 +166,7 @@ func (m mongoDB) GetCDSConfirm(loc schema.Location) (float64, float64, float64, 
 		delta = today.Cases - yesterday.Cases
 		if yesterday.Cases > 0 {
 			percent = 100 * delta / yesterday.Cases
-		} else {
+		} else if 0 == yesterday.Cases {
 			percent = 100
 		}
 		return today.Cases, delta, percent, nil

--- a/store/confirmCDS.go
+++ b/store/confirmCDS.go
@@ -34,7 +34,7 @@ type ConfirmCDS interface {
 	ReplaceCDS(result []schema.CDSData, country string) error
 	CreateCDS(result []schema.CDSData, country string) error
 	GetCDSConfirm(loc schema.Location) (float64, float64, float64, error)
-	ContinuousDataCDSConfirm(loc schema.Location, num int64, lessEqThan int64) ([]schema.CDSScoreDataSet, error)
+	ContinuousDataCDSConfirm(loc schema.Location, num int64, timeBefore int64) ([]schema.CDSScoreDataSet, error)
 }
 
 var CDSCountyCollectionMatrix = map[CDSCountryType]string{
@@ -154,7 +154,7 @@ func (m mongoDB) GetCDSConfirm(loc schema.Location) (float64, float64, float64, 
 	var delta float64
 	var today, yesterday schema.CDSData
 	if len(results) >= 2 {
-		if results[0].ReportTime != results[1].ReportTime {
+		if results[0].ReportTime > results[1].ReportTime {
 			today = results[0]
 			yesterday = results[1]
 		} else if results[0].ReportTime < results[1].ReportTime {

--- a/store/metric.go
+++ b/store/metric.go
@@ -92,12 +92,13 @@ func (m *mongoDB) CollectRawMetrics(location schema.Location) (*schema.Metric, e
 		log.WithFields(log.Fields{"prefix": mongoLogPrefix, "confirmedCount": confirmedCount, "confirmDiff": confirmDiff, "confirmDiffPercent": confirmDiffPercent}).Debug("confirm info")
 	}
 
-	confirmData, cnt, err := m.ContinuousDataCDSConfirm(location, 14, 0)
+	confirmData, err := m.ContinuousDataCDSConfirm(location, consts.ConfirmScoreWindowSize, 0)
 	if err != nil {
 		log.WithFields(log.Fields{"prefix": mongoLogPrefix, "error": err}).Error("confirm continuous data")
 		return nil, err
-	} else {
-		log.WithFields(log.Fields{"prefix": mongoLogPrefix, "count": cnt}).Debug("confirm continuous data")
+	}
+	if nil == confirmData {
+		confirmData = []schema.CDSScoreDataSet{}
 	}
 
 	return &schema.Metric{
@@ -123,7 +124,7 @@ func (m *mongoDB) CollectRawMetrics(location schema.Location) (*schema.Metric, e
 				TotalPeople:             totalPeopleReport,
 				MaxScorePerPerson:       schema.TotalOfficialBehaviorWeight,
 				CustomizedBehaviorTotal: float64(behaviorToday.CustomizedCount),
-				Score: behaviorScore,
+				Score:                   behaviorScore,
 			},
 		},
 	}, nil

--- a/store/metric.go
+++ b/store/metric.go
@@ -89,24 +89,25 @@ func (m *mongoDB) CollectRawMetrics(location schema.Location) (*schema.Metric, e
 		}).Error("confirm info")
 		return nil, err
 	} else {
-		log.WithFields(log.Fields{
-			"prefix":         mongoLogPrefix,
-			"latest_count":   confirmedCount,
-			"diff_yesterday": confirmDiff,
-			"percent":        confirmDiffPercent,
-		}).Debug("confirm metric")
+		log.WithFields(log.Fields{"prefix": mongoLogPrefix, "confirmedCount": confirmedCount, "confirmDiff": confirmDiff, "confirmDiffPercent": confirmDiffPercent}).Debug("confirm info")
+	}
 
+	confirmData, cnt, err := m.ContinuousDataCDSConfirm(location, 14, 0)
+	if err != nil {
+		log.WithFields(log.Fields{"prefix": mongoLogPrefix, "error": err}).Error("confirm continuous data")
+		return nil, err
+	} else {
+		log.WithFields(log.Fields{"prefix": mongoLogPrefix, "count": cnt}).Debug("confirm continuous data")
 	}
 
 	return &schema.Metric{
-		BehaviorCount:  float64(behaviorCount),
-		BehaviorDelta:  float64(behaviorDelta),
 		ConfirmedCount: confirmedCount,
 		ConfirmedDelta: confirmDiffPercent,
+		BehaviorCount:  float64(behaviorCount),
+		BehaviorDelta:  float64(behaviorDelta),
 		Details: schema.Details{
 			Confirm: schema.ConfirmDetail{
-				Yesterday: confirmedCount - confirmDiff,
-				Today:     confirmedCount,
+				ContinuousData: confirmData,
 			},
 			Symptoms: schema.SymptomDetail{
 				TotalPeople: float64(symptomUserCount),
@@ -122,7 +123,7 @@ func (m *mongoDB) CollectRawMetrics(location schema.Location) (*schema.Metric, e
 				TotalPeople:             totalPeopleReport,
 				MaxScorePerPerson:       schema.TotalOfficialBehaviorWeight,
 				CustomizedBehaviorTotal: float64(behaviorToday.CustomizedCount),
-				Score:                   behaviorScore,
+				Score: behaviorScore,
 			},
 		},
 	}, nil


### PR DESCRIPTION
Use the exponential formula for confirm-score 
- use  CDS data-set for Taiwan 
- use 14 days records  of confirm data to calculate the score
- use confirmDataCountThreadHold to control minimum data required

Formula link: https://github.com/bitmark-inc/autonomy-api/blob/master/share/jupyter/autonomyFormula.ipynb
