### PR TITLE
refactor symptom score calculation 

### DIFF
--- a/api/debug.go
+++ b/api/debug.go
@@ -61,11 +61,17 @@ func (s *Server) currentAreaDebugData(c *gin.Context) {
 		}
 		userCount = len(nearAccounts)
 
-		symptomCount, err = s.mongoStore.SymptomCount(consts.NEARBY_DISTANCE_RANGE, loc)
+		now := time.Now().UTC()
+		todayStartAt := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+		todayStartAtUnix := todayStartAt.Unix()
+		tomorrowStartAtUnix := todayStartAt.AddDate(0, 0, 1).Unix()
+		distribution, err := s.mongoStore.FindNearbySymptomDistribution(consts.NEARBY_DISTANCE_RANGE, loc, todayStartAtUnix, tomorrowStartAtUnix)
 		if err != nil {
-			c.Error(err)
 			abortWithEncoding(c, http.StatusInternalServerError, errorInternalServer, err)
 			return
+		}
+		for _, cnt := range distribution {
+			symptomCount += cnt
 		}
 	}
 
@@ -131,11 +137,17 @@ func (s *Server) poiDebugData(c *gin.Context) {
 		}
 		userCount = len(nearAccounts)
 
-		symptomCount, err = s.mongoStore.SymptomCount(consts.NEARBY_DISTANCE_RANGE, loc)
+		now := time.Now().UTC()
+		todayStartAt := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+		todayStartAtUnix := todayStartAt.Unix()
+		tomorrowStartAtUnix := todayStartAt.AddDate(0, 0, 1).Unix()
+		distribution, err := s.mongoStore.FindNearbySymptomDistribution(consts.NEARBY_DISTANCE_RANGE, loc, todayStartAtUnix, tomorrowStartAtUnix)
 		if err != nil {
-			c.Error(err)
 			abortWithEncoding(c, http.StatusInternalServerError, errorInternalServer, err)
 			return
+		}
+		for _, cnt := range distribution {
+			symptomCount += cnt
 		}
 
 	}

--- a/api/symptom.go
+++ b/api/symptom.go
@@ -247,9 +247,9 @@ func (s *Server) reportSymptoms(c *gin.Context) {
 }
 
 func (s *Server) findSymptomsInDB(ids []string) ([]schema.Symptom, []schema.Symptom, error) {
-	var syIDs []schema.SymptomType
+	var syIDs []string
 	for _, id := range ids {
-		syIDs = append(syIDs, schema.SymptomType(id))
+		syIDs = append(syIDs, id)
 	}
 	official, customeried, _, err := s.mongoStore.IDToSymptoms(syIDs)
 	return official, customeried, err

--- a/background/nudge/activities.go
+++ b/background/nudge/activities.go
@@ -159,7 +159,7 @@ func (n *NudgeWorker) NotifySymptomFollowUpActivity(ctx context.Context, account
 
 	logger.Info("Prepare the message context for following up symptoms", zap.Any("symptoms", symptoms))
 
-	var symptomsIDs = make([]schema.SymptomType, 0)
+	var symptomsIDs = make([]string, 0)
 	for _, s := range symptoms {
 		symptomsIDs = append(symptomsIDs, s.ID)
 	}
@@ -193,7 +193,7 @@ func (n *NudgeWorker) NotifySymptomSpikeActivity(ctx context.Context, accountNum
 
 	logger.Info("Prepare the message context for following up symptoms", zap.Any("symptoms", symptoms))
 
-	var symptomsIDs = make([]schema.SymptomType, 0)
+	var symptomsIDs = make([]string, 0)
 	for _, s := range symptoms {
 		symptomsIDs = append(symptomsIDs, s.ID)
 	}

--- a/background/score/activities.go
+++ b/background/score/activities.go
@@ -68,7 +68,7 @@ func (s *ScoreUpdateWorker) CalculatePOIStateActivity(ctx context.Context, id st
 	return &metric, nil
 }
 
-func (s *ScoreUpdateWorker) CheckLocationSpikeActivity(ctx context.Context, spikeSymptomTypes []schema.SymptomType) ([]schema.Symptom, error) {
+func (s *ScoreUpdateWorker) CheckLocationSpikeActivity(ctx context.Context, spikeSymptomTypes []string) ([]schema.Symptom, error) {
 	var spikeSymptom []schema.Symptom
 
 	if len(spikeSymptomTypes) > 0 {

--- a/schema/metric.go
+++ b/schema/metric.go
@@ -17,22 +17,18 @@ type BehaviorDetail struct {
 }
 
 type SymptomDetail struct {
-	SymptomTotal       float64             `json:"total_weight" bson:"total_weight"`
-	TotalPeople        float64             `json:"total_people" bson:"total_people"`
-	MaxScorePerPerson  float64             `json:"max_weight" bson:"max_weight"`
-	CustomizedWeight   float64             `json:"customized_weight" bson:"customized_weight"`
-	Score              float64             `json:"score" bson:"score"`
-	Symptoms           SymptomDistribution `json:"-" bson:"symptoms"`
-	LastSpikeUpdate    time.Time           `json:"last_spike_update" bson:"last_spike_update"`
-	LastSpikeList      []SymptomType       `json:"last_spike_types" bson:"last_spike_types"`
-	CustomSymptomCount float64             `json:"-" bson:"custom_symptom_count"`
-	TodayData          NearestSymptomData  `json:"today_data"  bson:"today_data"`
-	YesterdayData      NearestSymptomData  `json:"yesterday_data"  bson:"-"`
+	Score             float64            `json:"score" bson:"score"`
+	SymptomTotal      float64            `json:"total_weight" bson:"total_weight"`
+	TotalPeople       float64            `json:"total_people" bson:"total_people"`
+	MaxScorePerPerson float64            `json:"max_weight" bson:"max_weight"`
+	CustomizedWeight  float64            `json:"customized_weight" bson:"customized_weight"`
+	TodayData         NearestSymptomData `json:"today_data"  bson:"today_data"`
+	YesterdayData     NearestSymptomData `json:"-"  bson:"-"`
+	LastSpikeUpdate   time.Time          `json:"-" bson:"last_spike_update"`
+	LastSpikeList     []string           `json:"-" bson:"last_spike_types"`
 }
+
 type NearestSymptomData struct {
-	UserCount          float64             `json:"user_count" bson:"user_count"`
-	OfficialCount      float64             `json:"official_count" bson:"official_count"`
-	CustomizedCount    float64             `json:"customized_count" bson:"customized_count"`
 	WeightDistribution SymptomDistribution `json:"weight_distribution" bson:"weight_distribution"`
 }
 

--- a/schema/profile.go
+++ b/schema/profile.go
@@ -9,18 +9,18 @@ const (
 )
 
 // SymptomWeights is structure for customized symptom weights
-type SymptomWeights map[SymptomType]float64
+type SymptomWeights map[string]float64
 
 var (
 	DefaultSymptomWeights = SymptomWeights{
-		Fever:   3,
-		Cough:   2,
-		Fatigue: 1,
-		Breath:  1,
-		Nasal:   1,
-		Throat:  1,
-		Chest:   2,
-		Face:    2,
+		"fever":   3,
+		"cough":   2,
+		"fatigue": 1,
+		"breath":  1,
+		"nasal":   1,
+		"throat":  1,
+		"chest":   2,
+		"face":    2,
 	}
 )
 

--- a/schema/symptom.go
+++ b/schema/symptom.go
@@ -6,18 +6,6 @@ import (
 
 type SymptomType string
 
-// SymptomFromID is a map which key is Symptom.ID and value is a object of Symptom
-var SymptomFromID = map[SymptomType]Symptom{
-	SymptomType(Fever):   COVID19Symptoms[0],
-	SymptomType(Cough):   COVID19Symptoms[1],
-	SymptomType(Fatigue): COVID19Symptoms[2],
-	SymptomType(Breath):  COVID19Symptoms[3],
-	SymptomType(Nasal):   COVID19Symptoms[4],
-	SymptomType(Throat):  COVID19Symptoms[5],
-	SymptomType(Chest):   COVID19Symptoms[6],
-	SymptomType(Face):    COVID19Symptoms[7],
-}
-
 type SymptomSource string
 
 const (
@@ -50,6 +38,19 @@ type Symptom struct {
 	Source SymptomSource `json:"-" bson:"source"`
 	Weight float64       `json:"-" bson:"weight"`
 }
+
+var (
+	OfficialSymptoms = map[string]bool{
+		"fever":   true,
+		"cough":   true,
+		"fatigue": true,
+		"breath":  true,
+		"nasal":   true,
+		"throat":  true,
+		"chest":   true,
+		"face":    true,
+	}
+)
 
 // The system defined symptoms. The list will be inserted into database by migration function
 var COVID19Symptoms = []Symptom{
@@ -193,10 +194,9 @@ type SymptomReportData struct {
 	CustomizedSymptoms []Symptom `json:"customized_symptoms" bson:"customized_symptoms"`
 	Location           GeoJSON   `json:"location" bson:"location"`
 	Timestamp          int64     `json:"ts" bson:"ts"`
-	SymptomScore       float64   `json:"score" bson:"score"`
 }
 
-type SymptomDistribution map[SymptomType]int
+type SymptomDistribution map[string]int
 
 func (s *SymptomReportData) MarshalJSON() ([]byte, error) {
 	allSymptoms := append(s.OfficialSymptoms, s.CustomizedSymptoms...)

--- a/schema/symptom.go
+++ b/schema/symptom.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 )
 
-type SymptomType string
-
 type SymptomSource string
 
 const (
@@ -17,22 +15,10 @@ const (
 const (
 	SymptomCollection       = "symptom"
 	SymptomReportCollection = "symptomReport"
-	TotalSymptomWeight      = 9
-)
-
-const (
-	Fever   SymptomType = "fever"
-	Cough   SymptomType = "cough"
-	Fatigue SymptomType = "fatigue"
-	Breath  SymptomType = "breath"
-	Nasal   SymptomType = "nasal"
-	Throat  SymptomType = "throat"
-	Chest   SymptomType = "chest"
-	Face    SymptomType = "face"
 )
 
 type Symptom struct {
-	ID     SymptomType   `json:"id" bson:"_id"`
+	ID     string        `json:"id" bson:"_id"`
 	Name   string        `json:"name" bson:"name"`
 	Desc   string        `json:"desc" bson:"desc"`
 	Source SymptomSource `json:"-" bson:"source"`
@@ -54,14 +40,14 @@ var (
 
 // The system defined symptoms. The list will be inserted into database by migration function
 var COVID19Symptoms = []Symptom{
-	{Fever, "Fever", "Body temperature above 100ºF (38ºC)", OfficialSymptom, 2},
-	{Cough, "Dry cough", "Without mucous or phlegm (rattling)", OfficialSymptom, 2},
-	{Fatigue, "Fatigue or tiredness", "Unusual lack of energy or feeling run down", OfficialSymptom, 1},
-	{Breath, "Shortness of breath", "Constriction or difficulty inhaling fully", OfficialSymptom, 1},
-	{Nasal, "Nasal congestion", "Stuffy or blocked nose", OfficialSymptom, 1},
-	{Throat, "Sore throat", "Throat pain, scratchiness, or irritation", OfficialSymptom, 1},
-	{Chest, "Chest pain", "Persistent pain or pressure in the chest", OfficialSymptom, 1},
-	{Face, "Bluish lips or face", "Not caused by cold exposure", OfficialSymptom, 1},
+	{"fever", "Fever", "Body temperature above 100ºF (38ºC)", OfficialSymptom, 2},
+	{"cough", "Dry cough", "Without mucous or phlegm (rattling)", OfficialSymptom, 2},
+	{"fatigue", "Fatigue or tiredness", "Unusual lack of energy or feeling run down", OfficialSymptom, 1},
+	{"breath", "Shortness of breath", "Constriction or difficulty inhaling fully", OfficialSymptom, 1},
+	{"nasal", "Nasal congestion", "Stuffy or blocked nose", OfficialSymptom, 1},
+	{"throat", "Sore throat", "Throat pain, scratchiness, or irritation", OfficialSymptom, 1},
+	{"chest pain", "Chest pain", "Persistent pain or pressure in the chest", OfficialSymptom, 1},
+	{"face", "Bluish lips or face", "Not caused by cold exposure", OfficialSymptom, 1},
 }
 
 var GeneralSymptoms = []Symptom{

--- a/score/metric.go
+++ b/score/metric.go
@@ -46,8 +46,8 @@ func CheckScoreColorChange(oldScore, newScore float64) bool {
 
 // CheckSymptomSpike check if there is a spike for symptoms distribution
 // for a given metric data
-func CheckSymptomSpike(yesterdayDistribution, currentDistribution schema.SymptomDistribution) []schema.SymptomType {
-	spikeSymptoms := []schema.SymptomType{}
+func CheckSymptomSpike(yesterdayDistribution, currentDistribution schema.SymptomDistribution) []string {
+	spikeSymptoms := []string{}
 
 	for t, c1 := range currentDistribution {
 		if c0, ok := yesterdayDistribution[t]; ok {

--- a/score/symptom.go
+++ b/score/symptom.go
@@ -39,7 +39,7 @@ func CalculateSymptomScore(weights schema.SymptomWeights, metric schema.Metric) 
 		totalCountYesterday += cnt
 	}
 
-	maxWeightedSum := float64(rawData.TotalPeople) * (totalWeight + float64(nonOfficialCount))
+	maxWeightedSum := float64(rawData.TotalPeople)*totalWeight + float64(nonOfficialCount)
 	score := 100.0
 	if maxWeightedSum > 0 {
 		score = 100 * (1 - weightedSum/maxWeightedSum)

--- a/score/symptom.go
+++ b/score/symptom.go
@@ -21,8 +21,8 @@ func CalculateSymptomScore(weights schema.SymptomWeights, metric schema.Metric) 
 		var weight float64
 		var ok bool
 		if schema.OfficialSymptoms[symptomID] {
-			if weight, ok = weights[schema.SymptomType(symptomID)]; !ok {
-				weight = schema.DefaultSymptomWeights[schema.SymptomType(symptomID)]
+			if weight, ok = weights[symptomID]; !ok {
+				weight = schema.DefaultSymptomWeights[symptomID]
 			}
 			officialCount += cnt
 		} else {

--- a/score/symptom.go
+++ b/score/symptom.go
@@ -1,79 +1,65 @@
 package score
 
 import (
-	"fmt"
 	"time"
-
-	log "github.com/sirupsen/logrus"
 
 	"github.com/bitmark-inc/autonomy-api/schema"
 )
 
 func CalculateSymptomScore(weights schema.SymptomWeights, metric schema.Metric) schema.Metric {
-	today := metric.Details.Symptoms.TodayData
-	yesterday := metric.Details.Symptoms.YesterdayData
+	rawData := metric.Details.Symptoms
 
-	symptomScore, sTotalweight, sMaxScorePerPerson, sDeltaInPercent, sOfficialCount, sCustomizedCount :=
-		SymptomScore(weights, today, yesterday)
+	totalWeight := float64(0)
+	for _, w := range weights {
+		totalWeight += w
+	}
 
-	spikeList := CheckSymptomSpike(yesterday.WeightDistribution, today.WeightDistribution)
+	weightedSum := float64(0)
+	officialCount := 0
+	nonOfficialCount := 0
+	for symptomID, cnt := range rawData.TodayData.WeightDistribution {
+		var weight float64
+		var ok bool
+		if schema.OfficialSymptoms[symptomID] {
+			if weight, ok = weights[schema.SymptomType(symptomID)]; !ok {
+				weight = schema.DefaultSymptomWeights[schema.SymptomType(symptomID)]
+			}
+			officialCount += cnt
+		} else {
+			weight = 1
+			nonOfficialCount += cnt
+		}
 
-	metric.SymptomDelta = sDeltaInPercent
-	metric.SymptomCount = sOfficialCount + sCustomizedCount
+		weightedSum += float64(cnt) * weight
+	}
+
+	totalCountToday := officialCount + nonOfficialCount
+	totalCountYesterday := 0
+	for _, cnt := range rawData.YesterdayData.WeightDistribution {
+		totalCountYesterday += cnt
+	}
+
+	maxWeightedSum := float64(rawData.TotalPeople) * (totalWeight + float64(nonOfficialCount))
+	score := 100.0
+	if maxWeightedSum > 0 {
+		score = 100 * (1 - weightedSum/maxWeightedSum)
+	}
+
+	spikeList := CheckSymptomSpike(rawData.YesterdayData.WeightDistribution, rawData.TodayData.WeightDistribution)
+
+	metric.SymptomCount = float64(totalCountToday)
+	metric.SymptomDelta = ChangeRate(float64(totalCountToday), float64(totalCountYesterday))
 	metric.Details.Symptoms = schema.SymptomDetail{
-		LastSpikeList:      spikeList,
-		LastSpikeUpdate:    time.Now().UTC(),
-		SymptomTotal:       sTotalweight,
-		TotalPeople:        metric.Details.Symptoms.TodayData.UserCount,
-		Symptoms:           metric.Details.Symptoms.TodayData.WeightDistribution,
-		MaxScorePerPerson:  sMaxScorePerPerson,
-		CustomizedWeight:   sCustomizedCount,
-		CustomSymptomCount: sCustomizedCount,
-		Score:              symptomScore,
-		TodayData:          metric.Details.Symptoms.TodayData,
+		Score:             score,
+		SymptomTotal:      weightedSum,
+		MaxScorePerPerson: totalWeight,
+		TotalPeople:       float64(rawData.TotalPeople),
+		CustomizedWeight:  float64(nonOfficialCount),
+		TodayData:         metric.Details.Symptoms.TodayData,
+		YesterdayData:     metric.Details.Symptoms.YesterdayData,
+		LastSpikeList:     spikeList,
+		LastSpikeUpdate:   time.Now().UTC(),
 	}
 
 	return metric
-}
-
-func SymptomScore(weights schema.SymptomWeights, today, yesterday schema.NearestSymptomData) (float64, float64, float64, float64, float64, float64) {
-	countYesterday := yesterday.OfficialCount + yesterday.CustomizedCount
-	countToday := today.OfficialCount + today.CustomizedCount
-
-	// Today
-	maxScorePerPerson := float64(0) // Max Score,
-	for _, v := range weights {
-		maxScorePerPerson = maxScorePerPerson + v
-	}
-
-	if countYesterday <= 0 && countToday <= 0 {
-		return 100, 0, maxScorePerPerson, 0, 0, 0
-	}
-
-	totalOfficialWeight := float64(0)
-	var w float64
-	var ok bool
-	for k, v := range today.WeightDistribution {
-		if w, ok = weights[k]; !ok {
-			w = schema.DefaultSymptomWeights[k]
-		}
-		totalOfficialWeight += w * float64(v)
-		log.Info(fmt.Sprintf("SymptomScore : k :%v w :%v , v:%v, symptomTotal:%v", k, w, v, totalOfficialWeight))
-	}
-	totalWeight := totalOfficialWeight + today.CustomizedCount*1
-	score := float64(100)
-	if today.OfficialCount*maxScorePerPerson > 0 {
-		de := today.UserCount*maxScorePerPerson + today.CustomizedCount
-		score = 100 * (1 - totalWeight/de)
-	} else if today.CustomizedCount > 0 {
-		score = 100 * (1 - totalWeight/today.CustomizedCount)
-	}
-
-	// deltaCount in percent
-	deltaInPercent := float64(100)
-
-	if countYesterday > 0 {
-		deltaInPercent = (countToday - countYesterday) / countYesterday * 100
-	}
-	return score, totalWeight, maxScorePerPerson, deltaInPercent, today.OfficialCount, today.CustomizedCount * 1
 }

--- a/score/symptom_test.go
+++ b/score/symptom_test.go
@@ -55,14 +55,14 @@ func TestCalculateSymptomScoreUsingDefaultWeights(t *testing.T) {
 
 func TestCalculateSymptomScoreUsingCustomizedWeights(t *testing.T) {
 	weights := schema.SymptomWeights{
-		schema.Fever:   1,
-		schema.Cough:   1,
-		schema.Fatigue: 1,
-		schema.Breath:  1,
-		schema.Nasal:   1,
-		schema.Throat:  1,
-		schema.Chest:   1,
-		schema.Face:    1,
+		"fever":   1,
+		"cough":   1,
+		"fatigue": 1,
+		"breath":  1,
+		"nasal":   1,
+		"throat":  1,
+		"chest":   1,
+		"face":    1,
 	}
 	metric := schema.Metric{
 		Details: schema.Details{

--- a/score/symptom_test.go
+++ b/score/symptom_test.go
@@ -1,6 +1,7 @@
 package score
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,7 @@ func TestCalculateSymptomScoreUsingDefaultWeights(t *testing.T) {
 		},
 	}
 	updatedMetric := CalculateSymptomScore(schema.DefaultSymptomWeights, metric)
-	assert.Equal(t, 80.0, updatedMetric.Details.Symptoms.Score)
+	assert.Equal(t, "78.63", fmt.Sprintf("%.2f", updatedMetric.Details.Symptoms.Score))
 	assert.Equal(t, 28.0, updatedMetric.Details.Symptoms.SymptomTotal)
 	assert.Equal(t, 10.0, updatedMetric.Details.Symptoms.TotalPeople)
 	assert.Equal(t, 13.0, updatedMetric.Details.Symptoms.MaxScorePerPerson)
@@ -41,7 +42,7 @@ func TestCalculateSymptomScoreUsingDefaultWeights(t *testing.T) {
 
 	// the function must be idempotent
 	updatedMetric = CalculateSymptomScore(schema.DefaultSymptomWeights, metric)
-	assert.Equal(t, 80.0, updatedMetric.Details.Symptoms.Score)
+	assert.Equal(t, "78.63", fmt.Sprintf("%.2f", updatedMetric.Details.Symptoms.Score))
 	assert.Equal(t, 28.0, updatedMetric.Details.Symptoms.SymptomTotal)
 	assert.Equal(t, 10.0, updatedMetric.Details.Symptoms.TotalPeople)
 	assert.Equal(t, 13.0, updatedMetric.Details.Symptoms.MaxScorePerPerson)
@@ -83,7 +84,7 @@ func TestCalculateSymptomScoreUsingCustomizedWeights(t *testing.T) {
 		},
 	}
 	updatedMetric := CalculateSymptomScore(weights, metric)
-	assert.Equal(t, 88.0, updatedMetric.Details.Symptoms.Score)
+	assert.Equal(t, "85.37", fmt.Sprintf("%.2f", updatedMetric.Details.Symptoms.Score))
 	assert.Equal(t, 12.0, updatedMetric.Details.Symptoms.SymptomTotal)
 	assert.Equal(t, 10.0, updatedMetric.Details.Symptoms.TotalPeople)
 	assert.Equal(t, 8.0, updatedMetric.Details.Symptoms.MaxScorePerPerson)
@@ -109,7 +110,7 @@ func TestCalculateSymptomScoreNoReportYesterday(t *testing.T) {
 		},
 	}
 	updatedMetric := CalculateSymptomScore(schema.DefaultSymptomWeights, metric)
-	assert.Equal(t, 84.0, updatedMetric.Details.Symptoms.Score)
+	assert.Equal(t, "82.09", fmt.Sprintf("%.2f", updatedMetric.Details.Symptoms.Score))
 	assert.Equal(t, 12.0, updatedMetric.Details.Symptoms.SymptomTotal)
 	assert.Equal(t, 5.0, updatedMetric.Details.Symptoms.TotalPeople)
 	assert.Equal(t, 13.0, updatedMetric.Details.Symptoms.MaxScorePerPerson)

--- a/score/symptom_test.go
+++ b/score/symptom_test.go
@@ -1,4 +1,4 @@
-package score_test
+package score
 
 import (
 	"testing"
@@ -6,49 +6,142 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/bitmark-inc/autonomy-api/schema"
-	"github.com/bitmark-inc/autonomy-api/score"
 )
 
-func TestSymptomScoreWhenDoTwice(t *testing.T) {
-	yesterday := schema.NearestSymptomData{
-		UserCount:       1,
-		OfficialCount:   2,
-		CustomizedCount: 3,
-		WeightDistribution: map[schema.SymptomType]int{
-			schema.Fever:   1,
-			schema.Face:    1,
-			schema.Chest:   1,
-			schema.Throat:  1,
-			schema.Nasal:   1,
-			schema.Cough:   1,
-			schema.Fatigue: 1,
-			schema.Breath:  1,
+func TestCalculateSymptomScoreUsingDefaultWeights(t *testing.T) {
+	metric := schema.Metric{
+		Details: schema.Details{
+			Symptoms: schema.SymptomDetail{
+				TotalPeople: 10,
+				TodayData: schema.NearestSymptomData{
+					WeightDistribution: map[string]int{
+						"cough":       3, // weight 2
+						"fever":       7, // weight 3
+						"new-symptom": 1, // weight 1
+					}},
+				YesterdayData: schema.NearestSymptomData{
+					WeightDistribution: map[string]int{
+						"cough":       1,
+						"fever":       1,
+						"new-symptom": 2,
+					}},
+			},
 		},
 	}
+	updatedMetric := CalculateSymptomScore(schema.DefaultSymptomWeights, metric)
+	assert.Equal(t, 80.0, updatedMetric.Details.Symptoms.Score)
+	assert.Equal(t, 28.0, updatedMetric.Details.Symptoms.SymptomTotal)
+	assert.Equal(t, 10.0, updatedMetric.Details.Symptoms.TotalPeople)
+	assert.Equal(t, 13.0, updatedMetric.Details.Symptoms.MaxScorePerPerson)
+	assert.Equal(t, 1.0, updatedMetric.Details.Symptoms.CustomizedWeight)
+	assert.Equal(t, metric.Details.Symptoms.TodayData, updatedMetric.Details.Symptoms.TodayData)
+	assert.Equal(t, metric.Details.Symptoms.YesterdayData, updatedMetric.Details.Symptoms.YesterdayData)
+	assert.Equal(t, 11.0, updatedMetric.SymptomCount)
+	assert.Equal(t, 175.0, updatedMetric.SymptomDelta)
 
-	today := schema.NearestSymptomData{
-		UserCount:       2,
-		OfficialCount:   3,
-		CustomizedCount: 4,
-		WeightDistribution: map[schema.SymptomType]int{
-			schema.Fever:   2,
-			schema.Face:    2,
-			schema.Chest:   2,
-			schema.Throat:  3,
-			schema.Nasal:   3,
-			schema.Cough:   3,
-			schema.Fatigue: 4,
-			schema.Breath:  5,
+	// the function must be idempotent
+	updatedMetric = CalculateSymptomScore(schema.DefaultSymptomWeights, metric)
+	assert.Equal(t, 80.0, updatedMetric.Details.Symptoms.Score)
+	assert.Equal(t, 28.0, updatedMetric.Details.Symptoms.SymptomTotal)
+	assert.Equal(t, 10.0, updatedMetric.Details.Symptoms.TotalPeople)
+	assert.Equal(t, 13.0, updatedMetric.Details.Symptoms.MaxScorePerPerson)
+	assert.Equal(t, 1.0, updatedMetric.Details.Symptoms.CustomizedWeight)
+	assert.Equal(t, metric.Details.Symptoms.TodayData, updatedMetric.Details.Symptoms.TodayData)
+	assert.Equal(t, metric.Details.Symptoms.YesterdayData, updatedMetric.Details.Symptoms.YesterdayData)
+	assert.Equal(t, 11.0, updatedMetric.SymptomCount)
+	assert.Equal(t, 175.0, updatedMetric.SymptomDelta)
+}
+
+func TestCalculateSymptomScoreUsingCustomizedWeights(t *testing.T) {
+	weights := schema.SymptomWeights{
+		schema.Fever:   1,
+		schema.Cough:   1,
+		schema.Fatigue: 1,
+		schema.Breath:  1,
+		schema.Nasal:   1,
+		schema.Throat:  1,
+		schema.Chest:   1,
+		schema.Face:    1,
+	}
+	metric := schema.Metric{
+		Details: schema.Details{
+			Symptoms: schema.SymptomDetail{
+				TotalPeople: 10,
+				TodayData: schema.NearestSymptomData{
+					WeightDistribution: map[string]int{
+						"cough":       3, // weight 1
+						"fever":       7, // weight 1
+						"new-symptom": 2, // weight 1
+					}},
+				YesterdayData: schema.NearestSymptomData{
+					WeightDistribution: map[string]int{
+						"cough":       1,
+						"fever":       1,
+						"new-symptom": 2,
+					}},
+			},
 		},
 	}
+	updatedMetric := CalculateSymptomScore(weights, metric)
+	assert.Equal(t, 88.0, updatedMetric.Details.Symptoms.Score)
+	assert.Equal(t, 12.0, updatedMetric.Details.Symptoms.SymptomTotal)
+	assert.Equal(t, 10.0, updatedMetric.Details.Symptoms.TotalPeople)
+	assert.Equal(t, 8.0, updatedMetric.Details.Symptoms.MaxScorePerPerson)
+	assert.Equal(t, 2.0, updatedMetric.Details.Symptoms.CustomizedWeight)
+	assert.Equal(t, metric.Details.Symptoms.TodayData, updatedMetric.Details.Symptoms.TodayData)
+	assert.Equal(t, metric.Details.Symptoms.YesterdayData, updatedMetric.Details.Symptoms.YesterdayData)
+	assert.Equal(t, 12.0, updatedMetric.SymptomCount)
+	assert.Equal(t, 200.0, updatedMetric.SymptomDelta)
+}
 
-	y1, y2, y3, y4, y5, y6 := score.SymptomScore(schema.DefaultSymptomWeights, today, yesterday)
-	t1, t2, t3, t4, t5, t6 := score.SymptomScore(schema.DefaultSymptomWeights, today, yesterday)
+func TestCalculateSymptomScoreNoReportYesterday(t *testing.T) {
+	metric := schema.Metric{
+		Details: schema.Details{
+			Symptoms: schema.SymptomDetail{
+				TotalPeople: 5,
+				TodayData: schema.NearestSymptomData{
+					WeightDistribution: schema.SymptomDistribution{
+						"nasal":         10, // weight 1
+						"new-symptom-1": 1,  // weight 1
+						"new-symptom-2": 1,  // weight 1
+					}},
+			},
+		},
+	}
+	updatedMetric := CalculateSymptomScore(schema.DefaultSymptomWeights, metric)
+	assert.Equal(t, 84.0, updatedMetric.Details.Symptoms.Score)
+	assert.Equal(t, 12.0, updatedMetric.Details.Symptoms.SymptomTotal)
+	assert.Equal(t, 5.0, updatedMetric.Details.Symptoms.TotalPeople)
+	assert.Equal(t, 13.0, updatedMetric.Details.Symptoms.MaxScorePerPerson)
+	assert.Equal(t, 2.0, updatedMetric.Details.Symptoms.CustomizedWeight)
+	assert.Equal(t, metric.Details.Symptoms.TodayData, updatedMetric.Details.Symptoms.TodayData)
+	assert.Equal(t, metric.Details.Symptoms.YesterdayData, updatedMetric.Details.Symptoms.YesterdayData)
+	assert.Equal(t, 12.0, updatedMetric.SymptomCount)
+	assert.Equal(t, 100.0, updatedMetric.SymptomDelta)
+}
 
-	assert.Equal(t, t1, y1, "wrong symptom score")
-	assert.Equal(t, t2, y2, "wrong total weight")
-	assert.Equal(t, t3, y3, "wrong max score per person")
-	assert.Equal(t, t4, y4, "wrong delta in percent")
-	assert.Equal(t, t5, y5, "wrong official count")
-	assert.Equal(t, t6, y6, "wrong customized count")
+func TestCalculateSymptomScoreNoReportToday(t *testing.T) {
+	metric := schema.Metric{
+		Details: schema.Details{
+			Symptoms: schema.SymptomDetail{
+				TotalPeople: 5,
+				YesterdayData: schema.NearestSymptomData{
+					WeightDistribution: schema.SymptomDistribution{
+						"nasal":         10, // weight 1
+						"new-symptom-1": 1,  // weight 1
+						"new-symptom-2": 1,  // weight 1
+					}},
+			},
+		},
+	}
+	updatedMetric := CalculateSymptomScore(schema.DefaultSymptomWeights, metric)
+	assert.Equal(t, 100.0, updatedMetric.Details.Symptoms.Score)
+	assert.Equal(t, 0.0, updatedMetric.Details.Symptoms.SymptomTotal)
+	assert.Equal(t, 5.0, updatedMetric.Details.Symptoms.TotalPeople)
+	assert.Equal(t, 13.0, updatedMetric.Details.Symptoms.MaxScorePerPerson)
+	assert.Equal(t, 0.0, updatedMetric.Details.Symptoms.CustomizedWeight)
+	assert.Equal(t, metric.Details.Symptoms.TodayData, updatedMetric.Details.Symptoms.TodayData)
+	assert.Equal(t, metric.Details.Symptoms.YesterdayData, updatedMetric.Details.Symptoms.YesterdayData)
+	assert.Equal(t, 0.0, updatedMetric.SymptomCount)
+	assert.Equal(t, -100.0, updatedMetric.SymptomDelta)
 }

--- a/store/agg.go
+++ b/store/agg.go
@@ -52,6 +52,17 @@ func aggStageReportedYesterday(todayBeginTime int64) bson.M {
 	}
 }
 
+func aggStageReportedBetween(start, end int64) bson.M {
+	return bson.M{
+		"$match": bson.M{
+			"ts": bson.M{
+				"$gte": start,
+				"$lt":  end,
+			},
+		},
+	}
+}
+
 func aggStagePreventNullArray(fields ...string) bson.M {
 	targets := bson.M{}
 	for _, field := range fields {

--- a/store/history.go
+++ b/store/history.go
@@ -25,7 +25,7 @@ func (m *mongoDB) GetReportedSymptoms(accountNumber string, earierThan, limit in
 		return nil, err
 	}
 	// TODO: put the mapping in memory
-	mapping := make(map[schema.SymptomType]schema.Symptom)
+	mapping := make(map[string]schema.Symptom)
 	for _, s := range symptoms {
 		mapping[s.ID] = s
 	}

--- a/store/metric.go
+++ b/store/metric.go
@@ -51,15 +51,15 @@ func (m *mongoDB) CollectRawMetrics(location schema.Location) (*schema.Metric, e
 
 	behaviorScore, behaviorDelta, behaviorCount, totalPeopleReport := score.BehaviorScore(behaviorToday, behaviorYesterday)
 
-	sToday, err := m.FindNearbySymptomDistribution(consts.NEARBY_DISTANCE_RANGE, location, todayStartAtUnix, tomorrowStartAtUnix)
+	symptomDistToday, err := m.FindNearbySymptomDistribution(consts.NEARBY_DISTANCE_RANGE, location, todayStartAtUnix, tomorrowStartAtUnix)
 	if err != nil {
 		return nil, err
 	}
-	sYesterday, err := m.FindNearbySymptomDistribution(consts.NEARBY_DISTANCE_RANGE, location, yesterdayStartAtUnix, todayStartAtUnix)
+	symptomDistYesterday, err := m.FindNearbySymptomDistribution(consts.NEARBY_DISTANCE_RANGE, location, yesterdayStartAtUnix, todayStartAtUnix)
 	if err != nil {
 		return nil, err
 	}
-	sUserCount, err := m.FindNearbyReporterCount(consts.NEARBY_DISTANCE_RANGE, location, todayStartAtUnix, tomorrowStartAtUnix)
+	symptomUserCount, err := m.FindNearbyReporterCount(consts.NEARBY_DISTANCE_RANGE, location, todayStartAtUnix, tomorrowStartAtUnix)
 	if err != nil {
 		return nil, err
 	}
@@ -109,12 +109,12 @@ func (m *mongoDB) CollectRawMetrics(location schema.Location) (*schema.Metric, e
 				Today:     confirmedCount,
 			},
 			Symptoms: schema.SymptomDetail{
-				TotalPeople: float64(sUserCount),
+				TotalPeople: float64(symptomUserCount),
 				TodayData: schema.NearestSymptomData{
-					WeightDistribution: sToday,
+					WeightDistribution: symptomDistToday,
 				},
 				YesterdayData: schema.NearestSymptomData{
-					WeightDistribution: sYesterday,
+					WeightDistribution: symptomDistYesterday,
 				},
 			},
 			Behaviors: schema.BehaviorDetail{

--- a/store/metric.go
+++ b/store/metric.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -27,6 +26,13 @@ type Metric interface {
 // CollectRawMetrics will gather data from various of sources that is required to
 // calculate an autonomy score
 func (m *mongoDB) CollectRawMetrics(location schema.Location) (*schema.Metric, error) {
+	now := time.Now().UTC()
+	todayStartAt := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	yesterdayStartAtUnix := todayStartAt.AddDate(0, 0, -1).Unix()
+	todayStartAtUnix := todayStartAt.Unix()
+	tomorrowStartAtUnix := todayStartAt.AddDate(0, 0, 1).Unix()
+
 	// Processing behaviors data
 	behaviorToday, behaviorYesterday, err := m.NearestGoodBehavior(consts.CORHORT_DISTANCE_RANGE, location)
 	if err != nil {
@@ -45,14 +51,16 @@ func (m *mongoDB) CollectRawMetrics(location schema.Location) (*schema.Metric, e
 
 	behaviorScore, behaviorDelta, behaviorCount, totalPeopleReport := score.BehaviorScore(behaviorToday, behaviorYesterday)
 
-	// Processing symptoms data
-	symptomToday, symptomYesterday, err := m.NearestSymptomScore(consts.NEARBY_DISTANCE_RANGE, location)
-	log.Info(fmt.Sprintf("CollectRawMetrics: officialSymptomDistribution:%v , officialSymptomCount:%v, userCount:%v", symptomToday.WeightDistribution, symptomToday.OfficialCount, symptomToday.UserCount))
+	sToday, err := m.FindNearbySymptomDistribution(consts.NEARBY_DISTANCE_RANGE, location, todayStartAtUnix, tomorrowStartAtUnix)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"prefix": mongoLogPrefix,
-			"error":  err,
-		}).Error("NearestSymptomScore outcome")
+		return nil, err
+	}
+	sYesterday, err := m.FindNearbySymptomDistribution(consts.NEARBY_DISTANCE_RANGE, location, yesterdayStartAtUnix, todayStartAtUnix)
+	if err != nil {
+		return nil, err
+	}
+	sUserCount, err := m.FindNearbyReporterCount(consts.NEARBY_DISTANCE_RANGE, location, todayStartAtUnix, tomorrowStartAtUnix)
+	if err != nil {
 		return nil, err
 	}
 
@@ -95,16 +103,19 @@ func (m *mongoDB) CollectRawMetrics(location schema.Location) (*schema.Metric, e
 		BehaviorDelta:  float64(behaviorDelta),
 		ConfirmedCount: confirmedCount,
 		ConfirmedDelta: confirmDiffPercent,
-		//	SymptomCount:   sOfficialCount + sCustomizedCount,
-		//		SymptomDelta:   sDeltaInPercent,
 		Details: schema.Details{
 			Confirm: schema.ConfirmDetail{
 				Yesterday: confirmedCount - confirmDiff,
 				Today:     confirmedCount,
 			},
 			Symptoms: schema.SymptomDetail{
-				TodayData:     symptomToday,
-				YesterdayData: symptomYesterday,
+				TotalPeople: float64(sUserCount),
+				TodayData: schema.NearestSymptomData{
+					WeightDistribution: sToday,
+				},
+				YesterdayData: schema.NearestSymptomData{
+					WeightDistribution: sYesterday,
+				},
 			},
 			Behaviors: schema.BehaviorDetail{
 				BehaviorTotal:           behaviorCount,

--- a/store/profile.go
+++ b/store/profile.go
@@ -122,7 +122,7 @@ func (m *mongoDB) UpdateAreaProfileSymptom(symptoms []schema.Symptom, location s
 			log.WithField("prefix", mongoLogPrefix).Infof("query nearest distance with error: %s", errDecode)
 			return fmt.Errorf("nearest distance query decode record with error: %s", errDecode)
 		}
-		temp := make(map[schema.SymptomType]schema.Symptom, 0)
+		temp := make(map[string]schema.Symptom, 0)
 		for _, s := range symptoms {
 			temp[s.ID] = s
 		}

--- a/store/symptom.go
+++ b/store/symptom.go
@@ -28,11 +28,10 @@ type Symptom interface {
 	ListSuggestedSymptoms(lang string) ([]schema.Symptom, error)
 	ListCustomizedSymptoms() ([]schema.Symptom, error)
 	SymptomReportSave(data *schema.SymptomReportData) error
-	AreaCustomizedSymptomList(distInMeter int, location schema.Location) ([]schema.Symptom, error)
 	IDToSymptoms(ids []schema.SymptomType) ([]schema.Symptom, []schema.Symptom, []schema.SymptomType, error)
-	NearestSymptomScore(distInMeter int, location schema.Location) (schema.NearestSymptomData, schema.NearestSymptomData, error)
-	NearOfficialSymptomInfo(meter int, loc schema.Location) (schema.SymptomDistribution, float64, float64, error)
-	SymptomCount(meter int, loc schema.Location) (int, error)
+	FindNearbySymptomDistribution(dist int, loc schema.Location, start, end int64) (schema.SymptomDistribution, error)
+	FindNearbyReporterCount(dist int, loc schema.Location, start, end int64) (int, error)
+	FindNearbyNonOfficialSymptoms(dist int, loc schema.Location) ([]schema.Symptom, error)
 }
 
 func (m *mongoDB) CreateSymptom(symptom schema.Symptom) (string, error) {
@@ -227,437 +226,149 @@ func (m *mongoDB) IDToSymptoms(ids []schema.SymptomType) ([]schema.Symptom, []sc
 	return foundOfficial, foundCustomized, notFound, nil
 }
 
-func (m *mongoDB) AreaCustomizedSymptomList(distInMeter int, location schema.Location) ([]schema.Symptom, error) {
-	nonEmptyArray := bson.D{{"$match", bson.M{"customized_symptoms": bson.M{"$exists": true, "$ne": bson.A{}}}}}
-	c := m.client.Database(m.database).Collection(schema.SymptomReportCollection)
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-	log.Debug(fmt.Sprintf("AreaCustomizedSymptomList location long:%f, lat: %f ", location.Longitude, location.Latitude))
-	cur, err := c.Aggregate(ctx, mongo.Pipeline{geoAggregate(distInMeter, location), nonEmptyArray})
-	if nil != err {
-		log.WithField("prefix", mongoLogPrefix).Errorf("area  customized symptom list with error: %s", err)
-		return nil, fmt.Errorf("area  customized symptom list aggregate with error: %s", err)
-	}
-	cbMap := make(map[schema.SymptomType]schema.Symptom, 0)
-	for cur.Next(ctx) {
-		var b schema.SymptomReportData
-		if errDecode := cur.Decode(&b); errDecode != nil {
-			log.WithField("prefix", mongoLogPrefix).Infof("area  customized symptomwith error: %s", errDecode)
-			return nil, fmt.Errorf("area  customized symptom decode record with error: %s", errDecode)
-		}
-		for _, symptom := range b.CustomizedSymptoms {
-			cbMap[symptom.ID] = symptom
-		}
-	}
-	cSymptoms := make([]schema.Symptom, 0)
-	for _, b := range cbMap {
-		cSymptoms = append(cSymptoms, b)
-	}
-	return cSymptoms, nil
-}
-
-// NearestGoodBehaviorScore returns symptom raw data of today and yesterday
-func (m *mongoDB) NearestSymptomScore(distInMeter int, location schema.Location) (schema.NearestSymptomData, schema.NearestSymptomData, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	db := m.client.Database(m.database)
-	collection := db.Collection(schema.SymptomReportCollection)
-	todayBegin := todayStartAt()
-	log.Debugf("time period today > %v, yesterday %v~ %v ", todayBegin, todayBegin-86400, todayBegin)
-	geoStage := bson.D{{"$geoNear", bson.M{
-		"near":          bson.M{"type": "Point", "coordinates": bson.A{location.Longitude, location.Latitude}},
-		"distanceField": "dist",
-		"spherical":     true,
-		"maxDistance":   distInMeter,
-	}}}
-	timeStageToday := bson.D{{"$match", bson.M{"ts": bson.M{"$gte": todayBegin}}}}
-	timeStageYesterday := bson.D{{"$match", bson.M{"ts": bson.M{"$gte": todayBegin - 86400, "$lt": todayBegin}}}}
-
-	sortStage := bson.D{{"$sort", bson.D{{"ts", -1}}}}
-
-	groupStage := bson.D{
-		{"$group", bson.D{
-			{"_id", "$profile_id"},
-			{"symptom_score", bson.D{
-				{"$first", "$symptom_score"},
-			}},
-			{"account_number", bson.D{
-				{"$first", "$account_number"},
-			}},
-			{"official_symptoms", bson.D{
-				{"$first", "$official_symptoms"},
-			}},
-			{"customized_symptoms", bson.D{
-				{"$first", "$customized_symptoms"},
-			}},
-		}}}
-	officialDistribution := make(schema.SymptomDistribution)
-	cursor, err := collection.Aggregate(ctx, mongo.Pipeline{geoStage, timeStageToday, sortStage, groupStage})
-	if nil != err {
-		log.WithFields(log.Fields{"prefix": mongoLogPrefix, "error": err}).Error("aggregate nearest symptom score")
-		return schema.NearestSymptomData{}, schema.NearestSymptomData{}, err
-	}
-	userCount := int32(0)
-	OfficialSymptom := 0
-	CustomizedSymptom := 0
-	var dataToday schema.NearestSymptomData
-	for cursor.Next(ctx) {
-		var result schema.SymptomReportData
-		if err := cursor.Decode(&result); err != nil {
-			log.WithFields(log.Fields{"prefix": mongoLogPrefix, "error": err}).Error("decode nearest symptom score")
-			continue
-		}
-		userCount++
-		OfficialSymptom = OfficialSymptom + len(result.OfficialSymptoms)
-		CustomizedSymptom = CustomizedSymptom + len(result.CustomizedSymptoms)
-		for _, s := range result.OfficialSymptoms {
-			value, ok := officialDistribution[schema.SymptomType(s.ID)]
-			if !ok {
-				officialDistribution[s.ID] = 1
-			} else {
-				officialDistribution[s.ID] = value + 1
-			}
-		}
-		dataToday = schema.NearestSymptomData{
-			UserCount:          float64(userCount),
-			OfficialCount:      float64(OfficialSymptom),
-			CustomizedCount:    float64(CustomizedSymptom),
-			WeightDistribution: officialDistribution,
-		}
-	}
-
-	officialDistributionYesterday := make(schema.SymptomDistribution)
-	cursor, err = collection.Aggregate(ctx, mongo.Pipeline{geoStage, timeStageYesterday, sortStage, groupStage})
-	if nil != err {
-		log.WithFields(log.Fields{"prefix": mongoLogPrefix, "error": err}).Error("aggregate nearest symptom score")
-		return schema.NearestSymptomData{}, schema.NearestSymptomData{}, err
-	}
-	userCount = 0
-	OfficialSymptom = 0
-	CustomizedSymptom = 0
-	var dataYesterday schema.NearestSymptomData
-	for cursor.Next(ctx) {
-		var result schema.SymptomReportData
-		if err := cursor.Decode(&result); err != nil {
-			log.WithFields(log.Fields{"prefix": mongoLogPrefix, "error": err}).Error("decode nearest symptom score")
-			continue
-		}
-		userCount++
-		OfficialSymptom = OfficialSymptom + len(result.OfficialSymptoms)
-		CustomizedSymptom = CustomizedSymptom + len(result.CustomizedSymptoms)
-		for _, s := range result.OfficialSymptoms {
-			value, ok := officialDistributionYesterday[schema.SymptomType(s.ID)]
-			if !ok {
-				officialDistributionYesterday[s.ID] = 1
-			} else {
-				officialDistributionYesterday[s.ID] = value + 1
-			}
-		}
-		dataYesterday = schema.NearestSymptomData{
-			UserCount:          float64(userCount),
-			OfficialCount:      float64(OfficialSymptom),
-			CustomizedCount:    float64(CustomizedSymptom),
-			WeightDistribution: officialDistributionYesterday,
-		}
-	}
-
-	return dataToday, dataYesterday, nil
-
-}
-
-func (m *mongoDB) NearOfficialSymptomInfo(meter int, loc schema.Location) (schema.SymptomDistribution, float64, float64, error) {
-	c := m.client.Database(m.database).Collection(schema.ProfileCollection)
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-	defer cancel()
-
-	geoNear := bson.D{
-		{"$geoNear", bson.M{
-			"near": bson.M{
-				"type":        "Point",
-				"coordinates": bson.A{loc.Longitude, loc.Latitude},
-			},
-			"distanceField": "dist",
-			"maxDistance":   meter,
-			"spherical":     true,
-			"includeLocs":   "location",
-		}},
-	}
-
-	joinSymptoms := bson.D{
-		{"$lookup", bson.M{
-			"from":         schema.SymptomReportCollection,
-			"localField":   "account_number",
-			"foreignField": "account_number",
-			"as":           "symptoms",
-		}},
-	}
-
-	nonEmptyArray := bson.D{
-		{"$match", bson.M{
-			"symptoms": bson.M{
-				"$exists": true,
-				"$ne":     bson.A{},
-			},
-		}},
-	}
-
-	nonNil := bson.D{
-		{"$match", bson.M{
-			"symptoms.official_symptoms": bson.M{"$ne": nil},
-		}},
-	}
-
-	latestSymptoms := bson.D{
-		{"$project", bson.M{
-			"account_number": 1,
-			"symptoms": bson.M{
-				"$arrayElemAt": bson.A{"$symptoms.official_symptoms", -1},
-			},
-			"ts": bson.M{
-				"$arrayElemAt": bson.A{"$symptoms.ts", -1},
-			},
-		}},
-	}
-
-	todayBeginTime := todayStartAt()
-	updateToday := bson.D{
-		{"$match", bson.M{"ts": bson.M{"$gte": todayBeginTime}}},
-	}
-
-	cur, err := c.Aggregate(ctx, mongo.Pipeline{
-		geoNear,
-		joinSymptoms,
-		nonEmptyArray,
-		nonNil,
-		latestSymptoms,
-		updateToday,
-	})
-
-	if nil != err {
-		log.WithFields(log.Fields{
-			"prefix":   mongoLogPrefix,
-			"distance": meter,
-			"lat":      loc.Latitude,
-			"lng":      loc.Longitude,
-			"error":    err,
-		}).Error("aggregate nearby symptoms")
-		return schema.SymptomDistribution{}, 0, 0, err
-	}
-
-	type data struct {
-		AccountNumber string           `bson:"account_number"`
-		Symptoms      []schema.Symptom `bson:"symptoms"`
-		Timestamp     int64            `bson:"ts"`
-	}
-
-	var d data
-	distribution := make(schema.SymptomDistribution)
-	var symptomCount float64
-
-	for cur.Next(ctx) {
-		if err = cur.Decode(&d); err != nil {
-			log.WithFields(log.Fields{
-				"prefix":   mongoLogPrefix,
-				"distance": meter,
-				"lat":      loc.Latitude,
-				"lng":      loc.Longitude,
-				"error":    err,
-			}).Error("decode nearby official symptoms")
-			return schema.SymptomDistribution{}, 0, 0, err
-		}
-
-		for _, s := range d.Symptoms {
-			distribution[s.ID]++
-			symptomCount++
-		}
-	}
-
-	joinGeographic := bson.D{
-		{"$lookup", bson.M{
-			"from":         schema.GeographicCollection,
-			"localField":   "account_number",
-			"foreignField": "account_number",
-			"as":           "geographic",
-		}},
-	}
-
-	geoDataExist := bson.D{
-		{"$match", bson.M{
-			"geographic": bson.M{
-				"$exists": true,
-				"$ne":     bson.A{},
-			},
-		}},
-	}
-
-	latestGeo := bson.D{
-		{"$project", bson.M{
-			"account_number": 1,
-			"ts": bson.M{
-				"$arrayElemAt": bson.A{"$geographic.ts", -1},
-			},
-		}},
-	}
-
-	sumUser := bson.D{
-		{"$group", bson.M{
-			"_id": nil,
-			"total": bson.M{
-				"$sum": 1,
-			},
-		}},
-	}
-
-	cur, err = c.Aggregate(ctx, mongo.Pipeline{
-		geoNear,
-		joinGeographic,
-		geoDataExist,
-		latestGeo,
-		updateToday,
-		sumUser,
-	})
-
-	if nil != err {
-		log.WithFields(log.Fields{
-			"prefix":   mongoLogPrefix,
-			"distance": meter,
-			"lat":      loc.Latitude,
-			"lng":      loc.Longitude,
-			"error":    err,
-		}).Error("sum nearby user")
-		return schema.SymptomDistribution{}, 0, 0, err
-	}
-
-	type sumData struct {
-		Total int `bson:"total"`
-	}
-
-	var userSumData sumData
-
-	if cur.Next(ctx) {
-		err = cur.Decode(&userSumData)
-		if nil != err {
-			log.WithFields(log.Fields{
-				"prefix":   mongoLogPrefix,
-				"distance": meter,
-				"lat":      loc.Latitude,
-				"lng":      loc.Longitude,
-				"error":    err,
-			}).Error("decode nearby user count")
-			return distribution, 0, 0, err
-		}
-	}
-
-	log.WithFields(log.Fields{
-		"prefix":                        mongoLogPrefix,
-		"user_count":                    userSumData.Total,
-		"official_symptom_distribution": distribution,
-		"official_symptom_count":        symptomCount,
-	}).Debug("near symptom info")
-
-	return distribution, symptomCount, float64(userSumData.Total), nil
-}
-
-func (m *mongoDB) SymptomCount(meter int, loc schema.Location) (int, error) {
-	log.WithFields(log.Fields{
-		"prefix":   mongoLogPrefix,
-		"distance": meter,
-		"lat":      loc.Latitude,
-		"lng":      loc.Longitude,
-	}).Info("get symptom count")
-
+func (m *mongoDB) FindNearbySymptomDistribution(dist int, loc schema.Location, start, end int64) (schema.SymptomDistribution, error) {
 	c := m.client.Database(m.database).Collection(schema.SymptomReportCollection)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
-	geoNear := bson.D{
-		{"$geoNear", bson.M{
-			"near": bson.M{
-				"type":        "Point",
-				"coordinates": bson.A{loc.Longitude, loc.Latitude},
+	pipeline := []bson.M{
+		aggStageGeoProximity(dist, loc),
+		aggStageReportedBetween(start, end),
+		{
+			"$project": bson.M{
+				"profile_id":     1,
+				"account_number": 1,
+				"symptoms": bson.M{
+					"$concatArrays": bson.A{
+						bson.M{"$ifNull": bson.A{"$official_symptoms", bson.A{}}},
+						bson.M{"$ifNull": bson.A{"$customized_symptoms", bson.A{}}},
+					},
+				},
 			},
-			"distanceField": "dist",
-			"maxDistance":   meter,
-			"spherical":     true,
-			"includeLocs":   "location",
-		}},
+		},
+		{
+			"$unwind": bson.M{
+				"path":                       "$symptoms",
+				"preserveNullAndEmptyArrays": false,
+			},
+		},
+		{
+			"$group": bson.M{
+				"_id": "$profile_id",
+				"symptoms": bson.M{
+					"$addToSet": "$symptoms",
+				},
+			},
+		}, // for each user, the number of types of symptoms reported
+		{
+			"$unwind": bson.M{
+				"path":                       "$symptoms",
+				"preserveNullAndEmptyArrays": false,
+			},
+		},
+		{
+			"$group": bson.M{
+				"_id": "$symptoms._id",
+				"count": bson.M{
+					"$sum": 1,
+				},
+			},
+		}, // for each symptom, the number of users who have reported it
 	}
 
-	todayBeginTime := todayStartAt()
-	addedToday := bson.D{
-		{"$match", bson.M{
-			"ts": bson.M{
-				"$gte": todayBeginTime - 86400,
-			},
-		}},
+	cursor, err := c.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, err
+	}
+	var aggItem struct {
+		SymptomID string `bson:"_id"`
+		Count     int    `bson:"count"`
+	}
+	result := make(map[string]int)
+	for cursor.Next(ctx) {
+		if err := cursor.Decode(&aggItem); err != nil {
+			return nil, err
+		}
+		result[aggItem.SymptomID] = aggItem.Count
 	}
 
-	latestFirst := bson.D{
-		{"$sort", bson.M{
-			"ts": -1,
-		}},
+	return result, nil
+}
+
+func (m *mongoDB) FindNearbyReporterCount(dist int, loc schema.Location, start, end int64) (int, error) {
+	c := m.client.Database(m.database).Collection(schema.SymptomReportCollection)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	pipeline := []bson.M{
+		aggStageGeoProximity(dist, loc),
+		aggStageReportedBetween(start, end),
+		{
+			"$group": bson.M{
+				"_id": "$profile_id",
+				"count": bson.M{
+					"$sum": 1,
+				},
+			},
+		},
+		{
+			"$group": bson.M{
+				"_id": nil,
+				"count": bson.M{
+					"$sum": 1,
+				},
+			},
+		},
 	}
-
-	groupAll := bson.D{
-		{"$group", bson.M{
-			"_id": "$account_number",
-			"official": bson.M{
-				"$first": "$official_symptoms",
-			},
-			"customized": bson.M{
-				"$first": "$customized_symptoms",
-			},
-			"ts": bson.M{
-				"$first": "$ts",
-			},
-		}},
-	}
-
-	cur, err := c.Aggregate(ctx, mongo.Pipeline{
-		geoNear,
-		addedToday,
-		latestFirst,
-		groupAll,
-	})
-
-	if nil != err {
-		log.WithFields(log.Fields{
-			"prefix": mongoLogPrefix,
-			"error":  err,
-		}).Error("aggregate nearby symptoms")
+	cursor, err := c.Aggregate(ctx, pipeline)
+	if err != nil {
 		return 0, err
 	}
 
-	type aggregatedData struct {
-		AccountNumber string           `bson:"_id"`
-		Official      []schema.Symptom `bson:"official"`
-		Customized    []schema.Symptom `bson:"customized"`
-		Timestamp     int64            `bson:"ts"`
+	if !cursor.Next(ctx) {
+		return 0, nil
 	}
 
-	var data aggregatedData
-	var officialCount, customizedCount int
+	var result struct {
+		Count int `bson:"count"`
+	}
+	if err := cursor.Decode(&result); err != nil {
+		return 0, err
+	}
 
-	for cur.Next(ctx) {
-		err = cur.Decode(&data)
-		if nil != err {
-			log.WithFields(log.Fields{
-				"prefix": mongoLogPrefix,
-				"error":  err,
-			}).Error("decode aggregated symptoms")
-			return 0, err
+	return result.Count, nil
+}
+
+func (m *mongoDB) FindNearbyNonOfficialSymptoms(dist int, loc schema.Location) ([]schema.Symptom, error) {
+	distribution, err := m.FindNearbySymptomDistribution(dist, loc, 0, 9223372036854775807)
+	if err != nil {
+		return nil, err
+	}
+
+	nonOfficialSymptomIDs := make([]string, 0)
+	for symptomID := range distribution {
+		if !schema.OfficialSymptoms[symptomID] {
+			nonOfficialSymptomIDs = append(nonOfficialSymptomIDs, symptomID)
 		}
-
-		officialCount += len(data.Official)
-		customizedCount += len(data.Customized)
 	}
 
-	log.WithFields(log.Fields{
-		"prefix":           mongoLogPrefix,
-		"timestamp":        todayBeginTime,
-		"official_count":   officialCount,
-		"customized_count": customizedCount,
-	}).Debug("aggregated symptoms")
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
 
-	return officialCount + customizedCount, nil
+	c := m.client.Database(m.database).Collection(schema.SymptomCollection)
+	query := bson.M{"_id": bson.M{"$in": nonOfficialSymptomIDs}}
+	cursor, err := c.Find(ctx, query, options.Find().SetSort(bson.M{"_id": 1}))
+	if err != nil {
+		return nil, err
+	}
+	symptoms := make([]schema.Symptom, 0)
+	for cursor.Next(ctx) {
+		var s schema.Symptom
+		if err := cursor.Decode(&s); err != nil {
+			return nil, err
+		}
+		symptoms = append(symptoms, s)
+	}
+
+	return symptoms, nil
 }

--- a/store/symptom.go
+++ b/store/symptom.go
@@ -226,6 +226,22 @@ func (m *mongoDB) IDToSymptoms(ids []schema.SymptomType) ([]schema.Symptom, []sc
 	return foundOfficial, foundCustomized, notFound, nil
 }
 
+// FindNearbySymptomDistribution returns the mapping of each reported symptom and the number of users who have reported it
+// in the specified area and within the specified time rage.
+//
+// Duplicated reported symptoms of a user are seen as one symptom.
+//
+// Here's the example: within the specified time interval, assume there are following 5 reports:
+//
+// | user  | symptoms              |
+// |-------|-----------------------|
+// | userA | [cough, fever]        |
+// | userA | [fever, cough, nasal] |
+// | userB | [fever]               |
+// | userB | [fever]               |
+// | userB | [fever] 			    |
+//
+// symptom_distribution = {fever: 2, cough: 1, nasal: 1}
 func (m *mongoDB) FindNearbySymptomDistribution(dist int, loc schema.Location, start, end int64) (schema.SymptomDistribution, error) {
 	c := m.client.Database(m.database).Collection(schema.SymptomReportCollection)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
@@ -295,6 +311,8 @@ func (m *mongoDB) FindNearbySymptomDistribution(dist int, loc schema.Location, s
 	return result, nil
 }
 
+// FindNearbyReporterCount returns the number of users who have reported symptoms
+// in the specified area and within the specified time rage.
 func (m *mongoDB) FindNearbyReporterCount(dist int, loc schema.Location, start, end int64) (int, error) {
 	c := m.client.Database(m.database).Collection(schema.SymptomReportCollection)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
@@ -339,6 +357,7 @@ func (m *mongoDB) FindNearbyReporterCount(dist int, loc schema.Location, start, 
 	return result.Count, nil
 }
 
+// FindNearbyNonOfficialSymptoms returns non-official symptoms reported today in the specified area.
 func (m *mongoDB) FindNearbyNonOfficialSymptoms(dist int, loc schema.Location) ([]schema.Symptom, error) {
 	distribution, err := m.FindNearbySymptomDistribution(dist, loc, 0, 9223372036854775807)
 	if err != nil {


### PR DESCRIPTION
Main changes:
1. Add db functions `FindNearbySymptomDistribution`, `FindNearbyReporterCount`, `FindNearbyNonOfficialSymptoms`. Please refer to comments of these functions for more information.
2. The differentiation of official and non-official symptoms relies on the map `OfficialSymptoms` defined in `schema/symptom.go`, where keys are symptom IDs stored. It's easier to have varying official symptoms.
3. Add test cases for symptom score calculations.
4. Remove unused vars and functions.

There will be other PRs to handle the following issues:
1. Differentiate official and non-official symptoms by the map `OfficialSymptoms` in symptom report API.
2. Add test cases for db functions.
3. Add the migration script to update `customized_symptom` in collection `profile`.