### PR TITLE
Refactor behavior score calculation

### DIFF
--- a/schema/behavior_test.go
+++ b/schema/behavior_test.go
@@ -1,0 +1,24 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitBehaviors(t *testing.T) {
+	behaviors := []Behavior{
+		{ID: "touch_face"},
+		{ID: "something new"},
+		{ID: "social_distancing"},
+		{ID: "something brand new"},
+	}
+	official, nonOfficial := SplitBehaviors(behaviors)
+	assert.Equal(t, 2, len(official))
+	assert.Equal(t, "touch_face", string(official[0].ID))
+	assert.Equal(t, "social_distancing", string(official[1].ID))
+
+	assert.Equal(t, 2, len(nonOfficial))
+	assert.Equal(t, "something new", string(nonOfficial[0].ID))
+	assert.Equal(t, "something brand new", string(nonOfficial[1].ID))
+}

--- a/schema/goodBehavior.go
+++ b/schema/goodBehavior.go
@@ -69,7 +69,7 @@ var OfficialBehaviors = []Behavior{
 	{TouchFace, "Avoiding touching face", "Restraining from touching your eyes, nose, or mouth, especially with unwashed hands.", OfficialBehavior},
 	{WearMask, "Wearing a face mask or covering", "Covering your nose and mouth when in public or whenever social distancing measures are difficult to maintain.", OfficialBehavior},
 	{CoveringCough, "Covering coughs and sneezes", "Covering your mouth with the inside of your elbow or a tissue whenever you cough or sneeze.", OfficialBehavior},
-	{CleanSurface, "Cleaing and disinfecting surfaces", "Cleaning and disinfecting frequently touched surfaces daily, such as doorknobs, tables, light switches, and keyboards.", OfficialBehavior},
+	{CleanSurface, "Cleaning and disinfecting surfaces", "Cleaning and disinfecting frequently touched surfaces daily, such as doorknobs, tables, light switches, and keyboards.", OfficialBehavior},
 }
 
 // BehaviorReportData the struct to store citizen data and score
@@ -98,4 +98,19 @@ func (b *BehaviorReportData) MarshalJSON() ([]byte, error) {
 		Location:  Location{Longitude: b.Location.Coordinates[0], Latitude: b.Location.Coordinates[1]},
 		Timestamp: b.Timestamp,
 	})
+}
+
+// SplitBehaviors separates official and non-official behaviors
+func SplitBehaviors(behaviors []Behavior) ([]Behavior, []Behavior) {
+	official := make([]Behavior, 0)
+	nonOfficial := make([]Behavior, 0)
+	for _, s := range behaviors {
+		if _, ok := OfficialBehaviorMatrix[s.ID]; ok {
+			official = append(official, s)
+		} else {
+			nonOfficial = append(nonOfficial, s)
+		}
+	}
+
+	return official, nonOfficial
 }

--- a/schema/metric.go
+++ b/schema/metric.go
@@ -17,8 +17,8 @@ type BehaviorDetail struct {
 	CustomizedBehaviorTotal float64 `json:"behavior_customized_total" bson:"behavior_customized_total"`
 
 	Score                 float64        `json:"score" bson:"score"`
-	ReportTimes           int            `json:"x" bson:"-"`
-	TodayDistribution     map[string]int `json:"y" bson:"-"`
+	ReportTimes           int            `json:"-" bson:"-"`
+	TodayDistribution     map[string]int `json:"-" bson:"-"`
 	YesterdayDistribution map[string]int `json:"-" bson:"-"`
 }
 

--- a/schema/metric.go
+++ b/schema/metric.go
@@ -10,11 +10,16 @@ type ConfirmDetail struct {
 }
 
 type BehaviorDetail struct {
+	// FIXME: deprecate these fields
 	BehaviorTotal           float64 `json:"behavior_total" bson:"behavior_total"`
 	TotalPeople             float64 `json:"total_people" bson:"total_people"`
 	MaxScorePerPerson       float64 `json:"max_score_per_person" bson:"max_score_per_person"`
 	CustomizedBehaviorTotal float64 `json:"behavior_customized_total" bson:"behavior_customized_total"`
-	Score                   float64 `json:"score" bson:"score"`
+
+	Score                 float64        `json:"score" bson:"score"`
+	ReportTimes           int            `json:"x" bson:"-"`
+	TodayDistribution     map[string]int `json:"y" bson:"-"`
+	YesterdayDistribution map[string]int `json:"-" bson:"-"`
 }
 
 type SymptomDetail struct {

--- a/score/behavior_test.go
+++ b/score/behavior_test.go
@@ -1,0 +1,94 @@
+package score
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bitmark-inc/autonomy-api/schema"
+)
+
+func TestUpdateBehaviorMetrics(t *testing.T) {
+	metric := &schema.Metric{
+		Details: schema.Details{
+			Behaviors: schema.BehaviorDetail{
+				ReportTimes: 100,
+				TodayDistribution: map[string]int{
+					"clean_hand":        20,
+					"social_distancing": 10,
+					"touch_face":        10,
+					"wear_mask":         10,
+					"covering_coughs":   10,
+					"clean_surface":     10,
+					"new_behavior_1":    5,
+					"new_behavior_2":    5,
+				},
+				YesterdayDistribution: map[string]int{
+					"clean_hand": 20,
+				},
+			},
+		},
+	}
+	UpdateBehaviorMetrics(metric)
+	assert.Equal(t, "13.11", fmt.Sprintf("%.2f", metric.Details.Behaviors.Score))
+	assert.Equal(t, 80.0, metric.BehaviorCount)
+	assert.Equal(t, 300.0, metric.BehaviorDelta)
+}
+
+func TestCalculateBehaviorScoreNoReportToday(t *testing.T) {
+	metric := &schema.Metric{
+		Details: schema.Details{
+			Behaviors: schema.BehaviorDetail{
+				ReportTimes:       100,
+				TodayDistribution: map[string]int{},
+				YesterdayDistribution: map[string]int{
+					"clean_hand": 20,
+				},
+			},
+		},
+	}
+	UpdateBehaviorMetrics(metric)
+	assert.Equal(t, 0.0, metric.Details.Behaviors.Score)
+	assert.Equal(t, 0.0, metric.BehaviorCount)
+	assert.Equal(t, -100.0, metric.BehaviorDelta)
+
+	metric = &schema.Metric{
+		Details: schema.Details{
+			Behaviors: schema.BehaviorDetail{
+				ReportTimes:       100,
+				TodayDistribution: nil,
+				YesterdayDistribution: map[string]int{
+					"clean_hand": 20,
+				},
+			},
+		},
+	}
+	UpdateBehaviorMetrics(metric)
+	assert.Equal(t, 0.0, metric.Details.Behaviors.Score)
+	assert.Equal(t, 0.0, metric.BehaviorCount)
+	assert.Equal(t, -100.0, metric.BehaviorDelta)
+}
+
+func TestCalculateBehaviorScoreSignificantNonOfficialBehaviors(t *testing.T) {
+	metric := &schema.Metric{
+		Details: schema.Details{
+			Behaviors: schema.BehaviorDetail{
+				ReportTimes: 10,
+				TodayDistribution: map[string]int{
+					"clean_hand":     5,
+					"new_behavior_1": 30,
+					"new_behavior_2": 20,
+					"new_behavior_3": 20,
+				},
+				YesterdayDistribution: map[string]int{
+					"clean_hand": 20,
+				},
+			},
+		},
+	}
+	UpdateBehaviorMetrics(metric)
+	assert.Equal(t, "53.85", fmt.Sprintf("%.2f", metric.Details.Behaviors.Score))
+	assert.Equal(t, 75.0, metric.BehaviorCount)
+	assert.Equal(t, 275.0, metric.BehaviorDelta)
+}

--- a/score/behavior_test.go
+++ b/score/behavior_test.go
@@ -13,7 +13,7 @@ func TestUpdateBehaviorMetrics(t *testing.T) {
 	metric := &schema.Metric{
 		Details: schema.Details{
 			Behaviors: schema.BehaviorDetail{
-				ReportTimes: 100,
+				ReportTimes: 50,
 				TodayDistribution: map[string]int{
 					"clean_hand":        20,
 					"social_distancing": 10,
@@ -31,7 +31,7 @@ func TestUpdateBehaviorMetrics(t *testing.T) {
 		},
 	}
 	UpdateBehaviorMetrics(metric)
-	assert.Equal(t, "13.11", fmt.Sprintf("%.2f", metric.Details.Behaviors.Score))
+	assert.Equal(t, "25.81", fmt.Sprintf("%.2f", metric.Details.Behaviors.Score))
 	assert.Equal(t, 80.0, metric.BehaviorCount)
 	assert.Equal(t, 300.0, metric.BehaviorDelta)
 }
@@ -40,7 +40,7 @@ func TestCalculateBehaviorScoreNoReportToday(t *testing.T) {
 	metric := &schema.Metric{
 		Details: schema.Details{
 			Behaviors: schema.BehaviorDetail{
-				ReportTimes:       100,
+				ReportTimes:       0,
 				TodayDistribution: map[string]int{},
 				YesterdayDistribution: map[string]int{
 					"clean_hand": 20,

--- a/score/metric.go
+++ b/score/metric.go
@@ -67,6 +67,8 @@ func CheckSymptomSpike(yesterdayDistribution, currentDistribution schema.Symptom
 // CalculateMetric will calculate, summarize and return a metric based on collected raw metrics
 func CalculateMetric(rawMetrics schema.Metric, coefficient *schema.ScoreCoefficient) schema.Metric {
 	metric := rawMetrics
+
+	UpdateBehaviorMetrics(&metric)
 	CalculateConfirmScore(&metric)
 
 	if coefficient != nil {

--- a/store/account.go
+++ b/store/account.go
@@ -119,10 +119,7 @@ func (s *AutonomyStore) UpdateAccountGeoPosition(accountNumber string, latitude,
 	}
 
 	if exist {
-		err = s.mongo.UpdateAccountGeoPosition(a.AccountNumber, latitude, longitude)
-		if nil != err {
-			return err
-		}
+		return s.mongo.UpdateAccountGeoPosition(a.AccountNumber, latitude, longitude)
 	}
 
 	return s.mongo.CreateAccountWithGeoPosition(&a, latitude, longitude)

--- a/store/goodBehavior.go
+++ b/store/goodBehavior.go
@@ -185,6 +185,20 @@ func (m *mongoDB) IDToBehaviors(ids []schema.GoodBehaviorType) ([]schema.Behavio
 	return foundOfficial, foundCustomized, notFound, nil
 }
 
+// FindNearbyBehaviorDistribution returns the mapping of each reported symptom and the number of report times
+// in the specified area and within the specified time rage.
+//
+// Here's the example: within the specified time interval, assume there are following 5 reports:
+//
+// | user  | behaviors                                   |
+// |-------|---------------------------------------------|
+// | userA | [social_distancing, clean_hand]             |
+// | userA | [clean_hand, social_distancing, touch_face] |
+// | userB | [clean_hand]                                |
+// | userB | [clean_hand]                                |
+// | userB | [clean_hand] 		                         |
+//
+// behavior_distribution = {social_distancing: 2, clean_hand: 5, touch_face: 1}
 func (m *mongoDB) FindNearbyBehaviorDistribution(dist int, loc schema.Location, start, end int64) (map[string]int, error) {
 	c := m.client.Database(m.database).Collection(schema.BehaviorReportCollection)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
@@ -241,6 +255,10 @@ func (m *mongoDB) FindNearbyBehaviorDistribution(dist int, loc schema.Location, 
 	return result, nil
 }
 
+// FindNearbyBehaviorReportTimes returns the number of report times in the specified area and within the specified time rage.
+//
+// Take the same case described in the above function FindNearbyBehaviorDistribution for example,
+// the result is 5.
 func (m *mongoDB) FindNearbyBehaviorReportTimes(dist int, loc schema.Location, start, end int64) (int, error) {
 	c := m.client.Database(m.database).Collection(schema.BehaviorReportCollection)
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)

--- a/store/good_behavior_test.go
+++ b/store/good_behavior_test.go
@@ -1,0 +1,183 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/bitmark-inc/autonomy-api/consts"
+	"github.com/bitmark-inc/autonomy-api/schema"
+)
+
+var (
+	locationNangangTrainStation = schema.GeoJSON{
+		Type:        "Point",
+		Coordinates: []float64{121.605387, 25.052616},
+	}
+	locationSinica = schema.GeoJSON{
+		Type:        "Point",
+		Coordinates: []float64{121.616002, 25.042959},
+	}
+	locationBitmark = schema.GeoJSON{
+		Type:        "Point",
+		Coordinates: []float64{121.611905, 25.061037},
+	}
+	locationTaipeiTrainStation = schema.GeoJSON{
+		Type:        "Point",
+		Coordinates: []float64{121.517384, 25.047950},
+	}
+
+	tsMay25Morning = time.Date(2020, 5, 25, 9, 0, 0, 0, time.UTC).UTC().Unix()
+	tsMay26Morning = time.Date(2020, 5, 26, 9, 0, 0, 0, time.UTC).UTC().Unix()
+	tsMay26Evening = time.Date(2020, 5, 26, 17, 0, 0, 0, time.UTC).UTC().Unix()
+
+	// only behavior report #2, #3, and #4 should be taken into account
+	// because they are near Bitmark Taipei office and are reported during 2020 May 25
+	behaviorReport1 = schema.BehaviorReportData{
+		ProfileID: "userA",
+		OfficialBehaviors: []schema.Behavior{
+			{ID: "clean_hand"},
+			{ID: "social_distancing"},
+		},
+		Location:  locationNangangTrainStation,
+		Timestamp: tsMay25Morning,
+	}
+	behaviorReport2 = schema.BehaviorReportData{
+		ProfileID: "userA",
+		OfficialBehaviors: []schema.Behavior{
+			{ID: "clean_hand"},
+			{ID: "social_distancing"},
+		},
+		Location:  locationNangangTrainStation,
+		Timestamp: tsMay26Morning,
+	}
+	behaviorReport3 = schema.BehaviorReportData{
+		ProfileID: "userA",
+		OfficialBehaviors: []schema.Behavior{
+			{ID: "clean_hand"},
+			{ID: "social_distancing"},
+		},
+		Location:  locationSinica,
+		Timestamp: tsMay26Evening,
+	}
+	behaviorReport4 = schema.BehaviorReportData{
+		ProfileID: "userB",
+		OfficialBehaviors: []schema.Behavior{
+			{ID: "touch_face"},
+		},
+		CustomizedBehaviors: []schema.Behavior{
+			{ID: "new_behavior"},
+		},
+		Location:  locationBitmark,
+		Timestamp: tsMay26Morning,
+	}
+	behaviorReport5 = schema.BehaviorReportData{
+		ProfileID: "userB",
+		CustomizedBehaviors: []schema.Behavior{
+			{ID: "new_behavior"},
+		},
+		Location:  locationTaipeiTrainStation,
+		Timestamp: tsMay26Evening,
+	}
+)
+
+type BehaviorTestSuite struct {
+	suite.Suite
+	connURI      string
+	testDBName   string
+	mongoClient  *mongo.Client
+	testDatabase *mongo.Database
+}
+
+func NewBehaviorTestSuite(connURI, dbName string) *BehaviorTestSuite {
+	return &BehaviorTestSuite{
+		connURI:    connURI,
+		testDBName: dbName,
+	}
+}
+
+func (s *BehaviorTestSuite) SetupSuite() {
+	if s.connURI == "" || s.testDBName == "" {
+		s.T().Fatal("invalid test suite configuration")
+	}
+
+	opts := options.Client().ApplyURI(s.connURI)
+	mongoClient, err := mongo.NewClient(opts)
+	if nil != err {
+		s.T().Fatalf("create mongo client with error: %s", err)
+	}
+
+	if err = mongoClient.Connect(context.Background()); nil != err {
+		s.T().Fatalf("connect mongo database with error: %s", err.Error())
+	}
+
+	s.mongoClient = mongoClient
+	s.testDatabase = mongoClient.Database(s.testDBName)
+
+	// make sure the test suite is run with a clean environment
+	if err := s.CleanMongoDB(); err != nil {
+		s.T().Fatal(err)
+	}
+
+	schema.NewMongoDBIndexer(s.connURI, s.testDBName).IndexAll()
+
+	ctx := context.Background()
+	if _, err := s.testDatabase.Collection(schema.BehaviorReportCollection).InsertMany(ctx, []interface{}{
+		behaviorReport1,
+		behaviorReport2,
+		behaviorReport3,
+		behaviorReport4,
+		behaviorReport5,
+	}); err != nil {
+		s.T().Fatal(err)
+	}
+}
+
+// CleanMongoDB drop the whole test mongodb
+func (s *BehaviorTestSuite) CleanMongoDB() error {
+	return s.testDatabase.Drop(context.Background())
+}
+
+func (s *BehaviorTestSuite) TestFindNearbyBehaviorDistribution() {
+	store := NewMongoStore(s.mongoClient, s.testDBName)
+
+	start := time.Date(2020, 5, 26, 0, 0, 0, 0, time.UTC).UTC().Unix()
+	end := time.Date(2020, 5, 26, 24, 0, 0, 0, time.UTC).UTC().Unix()
+	distribution, err := store.FindNearbyBehaviorDistribution(
+		consts.CORHORT_DISTANCE_RANGE,
+		schema.Location{
+			Longitude: locationBitmark.Coordinates[0],
+			Latitude:  locationBitmark.Coordinates[1],
+		}, start, end)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), map[string]int{
+		"clean_hand":        2,
+		"social_distancing": 2,
+		"touch_face":        1,
+		"new_behavior":      1,
+	}, distribution)
+}
+
+func (s *BehaviorTestSuite) TestFindNearbyBehaviorReportTimes() {
+	store := NewMongoStore(s.mongoClient, s.testDBName)
+
+	start := time.Date(2020, 5, 26, 0, 0, 0, 0, time.UTC).UTC().Unix()
+	end := time.Date(2020, 5, 26, 24, 0, 0, 0, time.UTC).UTC().Unix()
+	count, err := store.FindNearbyBehaviorReportTimes(
+		consts.CORHORT_DISTANCE_RANGE,
+		schema.Location{
+			Longitude: locationBitmark.Coordinates[0],
+			Latitude:  locationBitmark.Coordinates[1],
+		}, start, end)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), 3, count)
+}
+
+func TestBehaviorTestSuite(t *testing.T) {
+	suite.Run(t, NewBehaviorTestSuite("mongodb://127.0.0.1:27017/?compressors=disabled", "test-db"))
+}


### PR DESCRIPTION
Similar to PR #58. This PR is to refactor behavior score calculation.

Unlike symptom score, duplicated reported items are taken into consideration for behavior score.

Main changes:
- Add new db functions for behavior score calculation and test cases.