### PR TITLE
use default symptom weights

### DIFF
--- a/score/metric.go
+++ b/score/metric.go
@@ -68,14 +68,13 @@ func CheckSymptomSpike(yesterdayDistribution, currentDistribution schema.Symptom
 func CalculateMetric(rawMetrics schema.Metric, coefficient *schema.ScoreCoefficient) schema.Metric {
 	metric := rawMetrics
 
+	UpdateSymptomMetrics(&metric)
 	UpdateBehaviorMetrics(&metric)
 	CalculateConfirmScore(&metric)
 
 	if coefficient != nil {
-		metric = CalculateSymptomScore(coefficient.SymptomWeights, metric)
 		metric.Score = TotalScoreV1(*coefficient, metric.Details.Symptoms.Score, metric.Details.Behaviors.Score, metric.Details.Confirm.Score)
 	} else {
-		metric = CalculateSymptomScore(schema.DefaultSymptomWeights, metric)
 		metric.Score = DefaultTotalScore(metric.Details.Symptoms.Score, metric.Details.Behaviors.Score, metric.Details.Confirm.Score)
 	}
 

--- a/score/symptom.go
+++ b/score/symptom.go
@@ -6,11 +6,11 @@ import (
 	"github.com/bitmark-inc/autonomy-api/schema"
 )
 
-func CalculateSymptomScore(weights schema.SymptomWeights, metric schema.Metric) schema.Metric {
+func UpdateSymptomMetrics(metric *schema.Metric) {
 	rawData := metric.Details.Symptoms
 
 	totalWeight := float64(0)
-	for _, w := range weights {
+	for _, w := range schema.DefaultSymptomWeights {
 		totalWeight += w
 	}
 
@@ -18,12 +18,8 @@ func CalculateSymptomScore(weights schema.SymptomWeights, metric schema.Metric) 
 	officialCount := 0
 	nonOfficialCount := 0
 	for symptomID, cnt := range rawData.TodayData.WeightDistribution {
-		var weight float64
-		var ok bool
-		if schema.OfficialSymptoms[symptomID] {
-			if weight, ok = weights[symptomID]; !ok {
-				weight = schema.DefaultSymptomWeights[symptomID]
-			}
+		weight, ok := schema.DefaultSymptomWeights[symptomID]
+		if ok {
 			officialCount += cnt
 		} else {
 			weight = 1
@@ -57,6 +53,4 @@ func CalculateSymptomScore(weights schema.SymptomWeights, metric schema.Metric) 
 		LastSpikeList:   spikeList,
 		LastSpikeUpdate: time.Now().UTC(),
 	}
-
-	return metric
 }

--- a/score/symptom_test.go
+++ b/score/symptom_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/bitmark-inc/autonomy-api/schema"
 )
 
-func TestCalculateSymptomScoreUsingDefaultWeights(t *testing.T) {
-	metric := schema.Metric{
+func TestUpdateSymptomMetrics(t *testing.T) {
+	metric := &schema.Metric{
 		Details: schema.Details{
 			Symptoms: schema.SymptomDetail{
 				TotalPeople: 10,
@@ -29,64 +29,22 @@ func TestCalculateSymptomScoreUsingDefaultWeights(t *testing.T) {
 			},
 		},
 	}
-	updatedMetric := CalculateSymptomScore(schema.DefaultSymptomWeights, metric)
-	assert.Equal(t, "76.86", fmt.Sprintf("%.2f", updatedMetric.Details.Symptoms.Score))
-	assert.Equal(t, 10.0, updatedMetric.Details.Symptoms.TotalPeople)
-	assert.Equal(t, metric.Details.Symptoms.TodayData, updatedMetric.Details.Symptoms.TodayData)
-	assert.Equal(t, metric.Details.Symptoms.YesterdayData, updatedMetric.Details.Symptoms.YesterdayData)
-	assert.Equal(t, 11.0, updatedMetric.SymptomCount)
-	assert.Equal(t, 175.0, updatedMetric.SymptomDelta)
+	UpdateSymptomMetrics(metric)
+	assert.Equal(t, "76.86", fmt.Sprintf("%.2f", metric.Details.Symptoms.Score))
+	assert.Equal(t, 10.0, metric.Details.Symptoms.TotalPeople)
+	assert.Equal(t, 11.0, metric.SymptomCount)
+	assert.Equal(t, 175.0, metric.SymptomDelta)
 
 	// the function must be idempotent
-	updatedMetric = CalculateSymptomScore(schema.DefaultSymptomWeights, metric)
-	assert.Equal(t, "76.86", fmt.Sprintf("%.2f", updatedMetric.Details.Symptoms.Score))
-	assert.Equal(t, 10.0, updatedMetric.Details.Symptoms.TotalPeople)
-	assert.Equal(t, metric.Details.Symptoms.TodayData, updatedMetric.Details.Symptoms.TodayData)
-	assert.Equal(t, metric.Details.Symptoms.YesterdayData, updatedMetric.Details.Symptoms.YesterdayData)
-	assert.Equal(t, 11.0, updatedMetric.SymptomCount)
-	assert.Equal(t, 175.0, updatedMetric.SymptomDelta)
+	UpdateSymptomMetrics(metric)
+	assert.Equal(t, "76.86", fmt.Sprintf("%.2f", metric.Details.Symptoms.Score))
+	assert.Equal(t, 10.0, metric.Details.Symptoms.TotalPeople)
+	assert.Equal(t, 11.0, metric.SymptomCount)
+	assert.Equal(t, 175.0, metric.SymptomDelta)
 }
 
-func TestCalculateSymptomScoreUsingCustomizedWeights(t *testing.T) {
-	weights := schema.SymptomWeights{
-		"cough":            1,
-		"breath":           1,
-		"fever":            1,
-		"chills":           1,
-		"muscle_pain":      1,
-		"throat":           1,
-		"loss_taste_smell": 1,
-	}
-	metric := schema.Metric{
-		Details: schema.Details{
-			Symptoms: schema.SymptomDetail{
-				TotalPeople: 10,
-				TodayData: schema.NearestSymptomData{
-					WeightDistribution: map[string]int{
-						"cough":       3, // weight 1
-						"fever":       7, // weight 1
-						"new-symptom": 2, // weight 1
-					}},
-				YesterdayData: schema.NearestSymptomData{
-					WeightDistribution: map[string]int{
-						"cough":       1,
-						"fever":       1,
-						"new-symptom": 2,
-					}},
-			},
-		},
-	}
-	updatedMetric := CalculateSymptomScore(weights, metric)
-	assert.Equal(t, "83.33", fmt.Sprintf("%.2f", updatedMetric.Details.Symptoms.Score))
-	assert.Equal(t, 10.0, updatedMetric.Details.Symptoms.TotalPeople)
-	assert.Equal(t, metric.Details.Symptoms.TodayData, updatedMetric.Details.Symptoms.TodayData)
-	assert.Equal(t, metric.Details.Symptoms.YesterdayData, updatedMetric.Details.Symptoms.YesterdayData)
-	assert.Equal(t, 12.0, updatedMetric.SymptomCount)
-	assert.Equal(t, 200.0, updatedMetric.SymptomDelta)
-}
-
-func TestCalculateSymptomScoreNoReportYesterday(t *testing.T) {
-	metric := schema.Metric{
+func TestUpdateSymptomMetricsNoReportYesterday(t *testing.T) {
+	metric := &schema.Metric{
 		Details: schema.Details{
 			Symptoms: schema.SymptomDetail{
 				TotalPeople: 5,
@@ -99,17 +57,15 @@ func TestCalculateSymptomScoreNoReportYesterday(t *testing.T) {
 			},
 		},
 	}
-	updatedMetric := CalculateSymptomScore(schema.DefaultSymptomWeights, metric)
-	assert.Equal(t, "48.39", fmt.Sprintf("%.2f", updatedMetric.Details.Symptoms.Score))
-	assert.Equal(t, 5.0, updatedMetric.Details.Symptoms.TotalPeople)
-	assert.Equal(t, metric.Details.Symptoms.TodayData, updatedMetric.Details.Symptoms.TodayData)
-	assert.Equal(t, metric.Details.Symptoms.YesterdayData, updatedMetric.Details.Symptoms.YesterdayData)
-	assert.Equal(t, 12.0, updatedMetric.SymptomCount)
-	assert.Equal(t, 100.0, updatedMetric.SymptomDelta)
+	UpdateSymptomMetrics(metric)
+	assert.Equal(t, "48.39", fmt.Sprintf("%.2f", metric.Details.Symptoms.Score))
+	assert.Equal(t, 5.0, metric.Details.Symptoms.TotalPeople)
+	assert.Equal(t, 12.0, metric.SymptomCount)
+	assert.Equal(t, 100.0, metric.SymptomDelta)
 }
 
-func TestCalculateSymptomScoreNoReportToday(t *testing.T) {
-	metric := schema.Metric{
+func TestUpdateSymptomMetricsNoReportToday(t *testing.T) {
+	metric := &schema.Metric{
 		Details: schema.Details{
 			Symptoms: schema.SymptomDetail{
 				TotalPeople: 5,
@@ -122,11 +78,9 @@ func TestCalculateSymptomScoreNoReportToday(t *testing.T) {
 			},
 		},
 	}
-	updatedMetric := CalculateSymptomScore(schema.DefaultSymptomWeights, metric)
-	assert.Equal(t, 100.0, updatedMetric.Details.Symptoms.Score)
-	assert.Equal(t, 5.0, updatedMetric.Details.Symptoms.TotalPeople)
-	assert.Equal(t, metric.Details.Symptoms.TodayData, updatedMetric.Details.Symptoms.TodayData)
-	assert.Equal(t, metric.Details.Symptoms.YesterdayData, updatedMetric.Details.Symptoms.YesterdayData)
-	assert.Equal(t, 0.0, updatedMetric.SymptomCount)
-	assert.Equal(t, -100.0, updatedMetric.SymptomDelta)
+	UpdateSymptomMetrics(metric)
+	assert.Equal(t, 100.0, metric.Details.Symptoms.Score)
+	assert.Equal(t, 5.0, metric.Details.Symptoms.TotalPeople)
+	assert.Equal(t, 0.0, metric.SymptomCount)
+	assert.Equal(t, -100.0, metric.SymptomDelta)
 }


### PR DESCRIPTION
The new UI doesn't enable users to adjust symptom weights. Thus the calculation uses default weights only.