### PR TITLE
sort poi by score

### DIFF
--- a/api/poi.go
+++ b/api/poi.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -296,6 +297,15 @@ func (s *Server) listPOI(c *gin.Context) {
 		}
 	}
 
+	sort.SliceStable(response, func(i, j int) bool {
+		if response[i].ResourceScore == nil {
+			return false
+		}
+		if response[j].ResourceScore == nil {
+			return true
+		}
+		return *response[i].ResourceScore > *response[j].ResourceScore
+	})
 	c.JSON(http.StatusOK, response)
 }
 


### PR DESCRIPTION
For the pilot run, we don't ask users to provide the current location. We simply sort the response by resource score instead.

It seems that only searching by resource ID requires location, but it's not used now.